### PR TITLE
feat: update go version for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.8
+        go-version: "1.17"
         stable: false
     - name: Setup qemu
       uses: docker/setup-qemu-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
       matrix:
         go-version:
         - 1.14.14
+        - "1.17"
         - 1.15.8
         - "1.16"
         os:
@@ -80,7 +81,7 @@ jobs:
     - name: Test
       run: go test ./...
     - if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/ci/')
-        && matrix.go-version == '1.15.8' && matrix.os == 'ubuntu-18.04' }}
+        && matrix.go-version == '1.17' && matrix.os == 'ubuntu-18.04' }}
       name: Test with -race
       run: go test -race ./...
     - name: gorelease check

--- a/cmd/cue/cmd/testdata/script/cmd_github.txt
+++ b/cmd/cue/cmd/testdata/script/cmd_github.txt
@@ -1372,7 +1372,7 @@ _#step: ((_#job & {
 _#codeGenGo: "1.14.14"
 
 // Use a specific latest version for release builds
-_#latestStableGo: "1.15.8"
+_#latestStableGo: "1.17"
 _#linuxMachine:   "ubuntu-18.04"
 _#macosMachine:   "macos-10.15"
 _#windowsMachine: "windows-2019"
@@ -1380,7 +1380,7 @@ _#testStrategy: {
 	"fail-fast": false
 	matrix: {
 		// Use a stable version of 1.14.x for go generate
-		"go-version": [_#codeGenGo, _#latestStableGo, "1.16"]
+		"go-version": [_#codeGenGo, _#latestStableGo, "1.15.8", "1.16"]
 		os: [_#linuxMachine, _#macosMachine, _#windowsMachine]
 	}
 }

--- a/cue/testdata/eval/github.txtar
+++ b/cue/testdata/eval/github.txtar
@@ -263,7 +263,7 @@ _#step: ((_#job & {
 _#codeGenGo: "1.14.14"
 
 // Use a specific latest version for release builds
-_#latestStableGo: "1.15.8"
+_#latestStableGo: "1.17"
 _#linuxMachine:   "ubuntu-18.04"
 _#macosMachine:   "macos-10.15"
 _#windowsMachine: "windows-2019"
@@ -271,7 +271,7 @@ _#testStrategy: {
 	"fail-fast": false
 	matrix: {
 		// Use a stable version of 1.14.x for go generate
-		"go-version": [_#codeGenGo, _#latestStableGo, "1.16"]
+		"go-version": [_#codeGenGo, _#latestStableGo, "1.15.8", "1.16"]
 		os: [_#linuxMachine, _#macosMachine, _#windowsMachine]
 	}
 }

--- a/internal/ci/workflows.cue
+++ b/internal/ci/workflows.cue
@@ -347,7 +347,7 @@ _#step: ((_#job & {steps:                 _}).steps & [_])[0]
 _#codeGenGo: "1.14.14"
 
 // Use a specific latest version for release builds
-_#latestStableGo: "1.15.8"
+_#latestStableGo: "1.17"
 
 _#linuxMachine:   "ubuntu-18.04"
 _#macosMachine:   "macos-10.15"
@@ -357,7 +357,7 @@ _#testStrategy: {
 	"fail-fast": false
 	matrix: {
 		// Use a stable version of 1.14.x for go generate
-		"go-version": [_#codeGenGo, _#latestStableGo, "1.16"]
+		"go-version": [_#codeGenGo, _#latestStableGo, "1.15.8", "1.16"]
 		os: [_#linuxMachine, _#macosMachine, _#windowsMachine]
 	}
 }


### PR DESCRIPTION
Go since version 1.16 supports darwin/amd64 and go-releaser supports this target from v0.156.0 so as far as I can tell this is the only change needed to support darwin/amd64 target