### PR TITLE
spec: Update example with regards to pattern constraints

### DIFF
--- a/doc/ref/spec.md
+++ b/doc/ref/spec.md
@@ -1091,10 +1091,10 @@ The token `...` is a shorthand for `..._`.
 
 ```
 a: {
-    foo:    string  // foo is a string
-    ["^i"]: int     // all other fields starting with i are integers
-    ["^b"]: bool    // all other fields starting with b are booleans
-    ...string       // all other fields must be a string
+    foo:    string    // foo is a string
+    [=~"^i"]: int     // all other fields starting with i are integers
+    [=~"^b"]: bool    // all other fields starting with b are booleans
+    ...string         // all other fields must be a string
 }
 
 b: a & {


### PR DESCRIPTION
The pattern constraint example is slightly incorrect and does not constrain
fields as it is supposed to.

The default constraint example also does not work, but this is not yet
implemented, see https://github.com/cue-lang/cue/issues/1109.

Signed-off-by: Scott Lewis-Kelly <slewiskelly@slewiskel.ly>