### PR TITLE
Fix doc string for CompileBytes and references

### DIFF
--- a/cue/build.go
+++ b/cue/build.go
@@ -101,7 +101,7 @@ func (r *hiddenRuntime) CompileExpr(expr ast.Expr) (*Instance, error) {
 // provided as a string, byte slice, or io.Reader. The name is used as the file
 // name in position information. The source may import builtin packages.
 //
-// Deprecated: use ParseString or ParseBytes.  The use of Instance is being
+// Deprecated: use CompileString or CompileBytes.  The use of Instance is being
 // phased out.
 func (r *hiddenRuntime) Parse(name string, source interface{}) (*Instance, error) {
 	return r.Compile(name, source)

--- a/cue/context.go
+++ b/cue/context.go
@@ -220,7 +220,7 @@ func (c *Context) CompileString(src string, options ...BuildOption) Value {
 	return c.compile(c.runtime().Compile(&cfg, src))
 }
 
-// ParseString parses and build a Value from the given source bytes.
+// CompileBytes parses and build a Value from the given source bytes.
 //
 // The returned Value will represent an error, accessible through Err, if any
 // error occurred.


### PR DESCRIPTION
Simple doc fix for `CompileBytes` function and docs that refers to it.