### PR TITLE
Add CIDR range verification function in net package

### DIFF
--- a/pkg/net/ip.go
+++ b/pkg/net/ip.go
@@ -75,6 +75,36 @@ func netGetIP(ip cue.Value) (goip net.IP) {
 	}
 }
 
+func netGetIPCIDR(ip cue.Value) (gonet *net.IPNet) {
+	switch ip.Kind() {
+	case cue.StringKind:
+		s, err := ip.String()
+		if err != nil {
+			return nil
+		}
+		_, gonet, err := net.ParseCIDR(s)
+		if err != nil {
+			return nil
+		}
+		return gonet
+
+	case cue.BytesKind:
+		b, err := ip.Bytes()
+		if err != nil {
+			return nil
+		}
+		_, gonet, err := net.ParseCIDR(string(b))
+		if err != nil {
+			return nil
+		}
+		return gonet
+
+	default:
+		// TODO: return canonical invalid type.
+		return nil
+	}
+}
+
 // ParseIP parses s as an IP address, returning the result.
 // The string s can be in dotted decimal ("192.0.2.1")
 // or IPv6 ("2001:db8::68") form.
@@ -110,6 +140,14 @@ func IPv4(ip cue.Value) bool {
 func IP(ip cue.Value) bool {
 	// TODO: convert to native CUE.
 	return netGetIP(ip) != nil
+}
+
+// IPCIDR reports whether ip is a valid IPv4 or IPv6 address with CIDR subnet notation.
+//
+// The address may be a string or list of bytes.
+func IPCIDR(ip cue.Value) bool {
+	// TODO: convert to native CUE.
+	return netGetIPCIDR(ip) != nil
 }
 
 // LoopbackIP reports whether ip is a loopback address.

--- a/pkg/net/pkg.go
+++ b/pkg/net/pkg.go
@@ -97,6 +97,18 @@ var pkg = &internal.Package{
 			}
 		},
 	}, {
+		Name: "IPCIDR",
+		Params: []internal.Param{
+			{Kind: adt.TopKind},
+		},
+		Result: adt.BoolKind,
+		Func: func(c *internal.CallCtxt) {
+			ip := c.Value(0)
+			if c.Do() {
+				c.Ret = IPCIDR(ip)
+			}
+		},
+	}, {
 		Name: "LoopbackIP",
 		Params: []internal.Param{
 			{Kind: adt.TopKind},

--- a/pkg/net/testdata/gen.txtar
+++ b/pkg/net/testdata/gen.txtar
@@ -20,6 +20,9 @@ t14: net.LoopbackIP([127, 0, 0, 1])
 t15: net.LoopbackIP("127.0.0.1")
 t16: net.ToIP4("127.0.0.1")
 t17: net.ToIP16("127.0.0.1")
+t18: net.IPCIDR("192.168.1.0/24")
+t19: net.IPCIDR("2001:db8:a0b:12f0::1/32")
+t20: net.IPCIDR("172.16.12.3")
 -- out/net --
 Errors:
 t9: invalid value "23.23.23.2333" (does not satisfy net.IPv4):
@@ -48,4 +51,7 @@ t14: true
 t15: true
 t16: [127, 0, 0, 1]
 t17: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 127, 0, 0, 1]
+t18: true
+t19: true
+t20: false
 


### PR DESCRIPTION
I've added a CIDR verification function, which helps in use-cases where CIDR ranges (and not individual IP addresses) need to be checked.