### PR TITLE
doc: mention the commit message hook for --signoff

### DIFF
--- a/doc/contribute.md
+++ b/doc/contribute.md
@@ -180,6 +180,9 @@ When committing, use the `--signoff` (or `-s`) flag:
 git commit -s
 ```
 
+You can also [set up a prepare-commit-msg git hook](#do-i-really-have-to-add-the--s-flag-to-each-commit)
+to not have to supply the `-s` flag.
+
 The explanations of the GitHub and GerritHub contribution workflows that follow
 assume all commits you create are signed-off in this way.
 


### PR DESCRIPTION
There's a useful section at the end of the doc
to set up a git hook so we don't have to specify -s.
Link to it when -s is first mentioned.

Signed-off-by: Daniel Martí <mvdan@mvdan.cc>