### PR TITLE
cue: fix output in ExampleContext

### DIFF
--- a/cue/examplecompile_test.go
+++ b/cue/examplecompile_test.go
@@ -44,7 +44,7 @@ func ExampleContext() {
 	// a:     2
 	// b:     3
 	// "a+b": 5
-
+	//
 	// expressions
 	// a + b: 5
 	// a * b: 6


### PR DESCRIPTION
If the output comment block of a testable example is not the last comment block then nothing will be tested. This commit combines the comment blocks so that the example actually tests against the output.

fixes #1267