### PR TITLE
WIP: tools/flow: return controller value

### DIFF
--- a/cmd/cue/cmd/custom.go
+++ b/cmd/cue/cmd/custom.go
@@ -131,7 +131,7 @@ func doTasks(cmd *Command, typ, command string, root *cue.Instance) error {
 
 	c := flow.New(cfg, root, newTaskFunc(cmd))
 
-	err := c.Run(context.Background())
+	_, err := c.Run(context.Background())
 	exitIfErr(cmd, root, err, true)
 
 	return err

--- a/tools/flow/flow.go
+++ b/tools/flow/flow.go
@@ -219,12 +219,12 @@ func New(cfg *Config, inst cue.InstanceOrValue, f TaskFunc) *Controller {
 }
 
 // Run runs the tasks of a workflow until completion.
-func (c *Controller) Run(ctx context.Context) error {
+func (c *Controller) Run(ctx context.Context) (cue.Value, error) {
 	c.context, c.cancelFunc = context.WithCancel(ctx)
 	defer c.cancelFunc()
 
 	c.runLoop()
-	return c.errs
+	return c.inst, c.errs
 }
 
 // A State indicates the state of a Task.

--- a/tools/flow/flow_test.go
+++ b/tools/flow/flow_test.go
@@ -81,7 +81,7 @@ func TestFlow(t *testing.T) {
 		c := flow.New(cfg, v, taskFunc)
 
 		w := t.Writer("errors")
-		if err := c.Run(context.Background()); err != nil {
+		if _, err := c.Run(context.Background()); err != nil {
 			cwd, _ := os.Getwd()
 			fmt.Fprint(w, "error: ")
 			errors.Print(w, err, &errors.Config{
@@ -209,7 +209,7 @@ func TestX(t *testing.T) {
 
 	t.Error(mermaidGraph(c))
 
-	if err := c.Run(context.Background()); err != nil {
+	if _, err := c.Run(context.Background()); err != nil {
 		t.Fatal(errors.Details(err, nil))
 	}
 }


### PR DESCRIPTION
This can be used to validate the value after the flow is completed, or
unifying the result value with the original value.

Change-Id: If588467ee85d061cce51fcbef2ab8c0fcdd3ead8
Signed-off-by: Jean-Philippe Braun <eon@patapon.info>