### PR TITLE
Allow hidden tasks in cue/flow

### DIFF
--- a/tools/flow/example_basic_test.go
+++ b/tools/flow/example_basic_test.go
@@ -33,6 +33,41 @@ func Example() {
 	// setting b.output to "hello hello world"
 }
 
+func ExampleHidden() {
+	var r cue.Runtime
+	inst, err := r.Compile("example.cue", `
+	a: {
+		input: "world"
+		output: string
+	}
+	b: {
+		input: a.output
+		output: string
+	}
+	_c: {
+		input: b.output
+		output: string
+	}
+	d: {
+		input: _c.output
+		output: string
+	}
+	`)
+	if err != nil {
+		log.Fatal(err)
+	}
+	controller := flow.New(&flow.Config{FindHiddenTasks: true}, inst, ioTaskFunc)
+	// controller := flow.New(nil, inst, ioTaskFunc)
+	if err := controller.Run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+	// Output:
+	// setting a.output to "hello world"
+	// setting b.output to "hello hello world"
+	// setting _c.output to "hello hello hello world"
+	// setting d.output to "hello hello hello hello world"
+}
+
 func ioTaskFunc(v cue.Value) (flow.Runner, error) {
 	inputPath := cue.ParsePath("input")
 

--- a/tools/flow/flow.go
+++ b/tools/flow/flow.go
@@ -135,6 +135,8 @@ type Config struct {
 	// concrete and cannot change.
 	IgnoreConcrete bool
 
+	FindHiddenTasks bool
+
 	// UpdateFunc is called whenever the information in the controller is
 	// updated. This includes directly after initialization. The task may be
 	// nil if this call is not the result of a task completing.

--- a/tools/flow/tasks.go
+++ b/tools/flow/tasks.go
@@ -68,7 +68,13 @@ func (c *Controller) findRootTasks(v cue.Value) {
 		return
 	}
 
-	for iter, _ := v.Fields(); iter.Next(); {
+	opts := []cue.Option{}
+
+	if c.cfg.FindHiddenTasks {
+		opts = append(opts, cue.Hidden(true))
+	}
+
+	for iter, _ := v.Fields(opts...); iter.Next(); {
 		c.findRootTasks(iter.Value())
 	}
 }


### PR DESCRIPTION
Allow hidden fields contain tasks would be very useful for us on the dagger team. 

This PR adds a configuration field for `cue/flow` to enable hidden fields as tasks, and includes a small test. 