### PR TITLE
cue: fix NPE in `BuildInstances`.

### DIFF
--- a/cue/context.go
+++ b/cue/context.go
@@ -143,8 +143,10 @@ func (c *Context) BuildInstances(instances []*build.Instance) ([]Value, error) {
 		v, err := c.runtime().Build(nil, b)
 		if err != nil {
 			errs = errors.Append(errs, err)
+			a = append(a, c.makeError(err))
+		} else {
+			a = append(a, c.make(v))
 		}
-		a = append(a, c.make(v))
 	}
 	return a, errs
 }


### PR DESCRIPTION
I hit the following NPE downstream playing with Cue for sigstore/cosign policies:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x10 pc=0x100847180]

goroutine 1 [running]:
cuelang.org/go/internal/core/adt.(*Vertex).getNodeContext(0x0, 0x140005d3d40)
        /Users/mattmoor/go/pkg/mod/cuelang.org/go@v0.4.0/internal/core/adt/eval.go:911 +0x20
cuelang.org/go/internal/core/adt.(*OpContext).Unify(0x140005d3d40, 0x0, 0x5)
        /Users/mattmoor/go/pkg/mod/cuelang.org/go@v0.4.0/internal/core/adt/eval.go:172 +0x38
cuelang.org/go/internal/core/adt.(*Vertex).Finalize(...)
        /Users/mattmoor/go/pkg/mod/cuelang.org/go@v0.4.0/internal/core/adt/composite.go:445
cuelang.org/go/cue.newVertexRoot(0x1400020c1e0, 0x140005d3d40, 0x0)
        /Users/mattmoor/go/pkg/mod/cuelang.org/go@v0.4.0/cue/types.go:615 +0x70
cuelang.org/go/cue.newValueRoot(0x1400020c1e0, 0x140005d3d40, {0x102353138, 0x0})
        /Users/mattmoor/go/pkg/mod/cuelang.org/go@v0.4.0/cue/types.go:624 +0x4c
cuelang.org/go/cue.(*Context).make(0x1400020c1e0, 0x0)
        /Users/mattmoor/go/pkg/mod/cuelang.org/go@v0.4.0/cue/context.go:246 +0x70
cuelang.org/go/cue.(*Context).BuildInstances(0x1400020c1e0, {0x14000010ae8, 0x1, 0x1})
        /Users/mattmoor/go/pkg/mod/cuelang.org/go@v0.4.0/cue/context.go:147 +0xf8
```

Examining the callstack it seems that `c.make(v)` is called when `v` is `nil`, which makes sense since the error path appends the error and then falls through.