### PR TITLE
doc/tutorial: fix typo in 55_defs.txt

### DIFF
--- a/doc/tutorial/basics/2_types/55_defs.txt
+++ b/doc/tutorial/basics/2_types/55_defs.txt
@@ -9,7 +9,7 @@ description = ""
 A definition, indicated by an identifier starting with `#` or `_#`,
 defines values that
 are not output when converting a configuration to a concrete value.
-They are used to define schemata against which concrete values can
+They are used to define schema against which concrete values can
 be validated.
 
 Structs defined by definitions are implicitly closed.


### PR DESCRIPTION
Teeny tiny spelling fix which I noticed while going through the tutorial