### PR TITLE
internal/core/export: avoid ".0" suffix for int53 representable numbers

### DIFF
--- a/internal/core/export/export_test.go
+++ b/internal/core/export/export_test.go
@@ -214,6 +214,22 @@ func TestGenerated(t *testing.T) {
 		out: ``, // empty file
 	}, {
 		in: func(r *adt.OpContext) (adt.Expr, error) {
+			n := 1.2
+			v := ctx.Encode(n)
+			_, x := value.ToInternal(v)
+			return x, nil
+		},
+		out: `1.2`,
+	}, {
+		in: func(r *adt.OpContext) (adt.Expr, error) {
+			n := float64(3)
+			v := ctx.Encode(n)
+			_, x := value.ToInternal(v)
+			return x, nil
+		},
+		out: `3`,
+	}, {
+		in: func(r *adt.OpContext) (adt.Expr, error) {
 			v := &adt.Vertex{}
 			v.SetValue(r, adt.Finalized, &adt.StructMarker{})
 			return v, nil


### PR DESCRIPTION
When encoding Go values, it is common for data parsed from JSON to
contain float64 values when the expected information is an integer.
During export, converting numbers to ASTs attempts to preserve float vs
int encoding, but in the absence of hints, fallsback to float encoding,
producing ".0" formatted output.

This change includes an added heuristic, which fallsback to float
encoding iif the value cannot be precisely represented as an integer
within a float64 value. That is, values within the the range of a 53-bit
signed integer are printed as integers, otherwise as floats.