### PR TITLE
doc/ref/spec.md: fix hello world example in spec

### DIFF
--- a/doc/ref/spec.md
+++ b/doc/ref/spec.md
@@ -2872,9 +2872,9 @@ SourceFile = { attribute "," } [ PackageClause "," ] { ImportDecl "," } { Declar
 ```
 
 ```
-"Hello \(place)!"
+"Hello \(#place)!"
 
-place: "world"
+#place: "world"
 
 // Outputs "Hello world!"
 ```


### PR DESCRIPTION
This PR is a trivial fix to an example in the spec. The example in question is:

```cue
"Hello \(place)!"

place: "world"

// Outputs "Hello world!"
```

If you run this with `cue export`, you get:

```
$ cue export hello.cue
conflicting values "Hello world!" and {"Hello \(〈0;place〉)!",place:"world"} (mismatched types string and struct):
    ./hello.cue:1:1
```

The with the amended example you get

```
$ cue export hello-fixed.cue
"Hello world!"
```

I know this might seem trivial, but while poring through the spec to internalize it for my WIP Rust implementation of CUE, this caught me off guard :smile: 