### PR TITLE
cue: float64 support for zero

### DIFF
--- a/cue/types.go
+++ b/cue/types.go
@@ -528,6 +528,9 @@ func (v Value) Float64() (float64, error) {
 	if err != nil {
 		return 0, err
 	}
+	if n.X.IsZero() {
+		return 0.0, nil
+	}
 	if n.X.Negative {
 		if n.X.Cmp(smallestNegFloat64) == 1 {
 			return -0, ErrAbove

--- a/cue/types_test.go
+++ b/cue/types_test.go
@@ -460,6 +460,14 @@ func TestFloat(t *testing.T) {
 		fmt:     'g',
 		kind:    IntKind,
 	}, {
+		value:   "0.0",
+		float:   "0.0",
+		mant:    "0",
+		exp:     -1,
+		float64: 0.0,
+		fmt:     'g',
+		kind:    FloatKind,
+	}, {
 		value:   "1.0",
 		float:   "1.0",
 		mant:    "10",

--- a/pkg/strconv/testdata/gen.txtar
+++ b/pkg/strconv/testdata/gen.txtar
@@ -12,6 +12,7 @@ t6: strconv.FormatInt(170_141_183_460_469_231_731_687_303_715_884_105_728, 10)
 t7: strconv.FormatInt(64, 16)
 t8: strconv.FormatUint(170_141_183_460_469_231_731_687_303_715_884_105_728, 10)
 t9: strconv.FormatUint(61, 62)
+t10: strconv.FormatFloat(0.0, 102, -1, 64)
 -- out/strconv --
 Errors:
 t2: int 300 overflows byte in argument 1 in call to strconv.FormatFloat:
@@ -23,13 +24,14 @@ t4: cannot use 1.0 (type float) as int in argument 2 to strconv.FormatFloat:
     ./in.cue:6:31
 
 Result:
-t1: "40"
-t2: _|_ // t2: int 300 overflows byte in argument 1 in call to strconv.FormatFloat
-t3: _|_ // t3: cannot use -1 (type int) as byte in argument 1 to strconv.FormatFloat
-t4: _|_ // t4: cannot use 1.0 (type float) as int in argument 2 to strconv.FormatFloat
-t5: "true"
-t6: "170141183460469231731687303715884105728"
-t7: "40"
-t8: "170141183460469231731687303715884105728"
-t9: "Z"
+t1:  "40"
+t2:  _|_ // t2: int 300 overflows byte in argument 1 in call to strconv.FormatFloat
+t3:  _|_ // t3: cannot use -1 (type int) as byte in argument 1 to strconv.FormatFloat
+t4:  _|_ // t4: cannot use 1.0 (type float) as int in argument 2 to strconv.FormatFloat
+t5:  "true"
+t6:  "170141183460469231731687303715884105728"
+t7:  "40"
+t8:  "170141183460469231731687303715884105728"
+t9:  "Z"
+t10: "0"
 


### PR DESCRIPTION
Fix the error when attempting to use strconv.FormatFloat with a zero value:

cannot use 0.0 (type float) as float64 in argument 0 to strconv.FormatFloat: value was rounded down

The tests for maximum and minimum in Float64() do not allow for zero.  The below check incorrectly sees zero as smaller, because the Sign() of zero (0) is less than the Sign() of smallestPosFloat64 (1).  So, it was clear this logic was not accounting for zero.

		if n.X.Cmp(smallestPosFloat64) == -1 {

closes #1669 

Signed-off-by: Kevin Burge <kcburge@pm.me>