### PR TITLE
ignore irregular files

### DIFF
--- a/cue/load/import.go
+++ b/cue/load/import.go
@@ -174,7 +174,15 @@ func (l *loader) importPkg(pos token.Pos, p *build.Instance) []*build.Instance {
 				return retErr(errors.Wrapf(err, pos, "import failed reading dir %v", dirs[0][1]))
 			}
 			for _, f := range files {
-				if f.IsDir() {
+				switch mode := f.Mode(); mode & os.ModeType {
+				case 0:
+				case os.ModeDir:
+					continue
+				default:
+					p.UnknownFiles = append(p.UnknownFiles, &build.File{
+						Filename:      f.Name(),
+						ExcludeReason: errors.Newf(token.NoPos, "unknown file %d", mode),
+					})
 					continue
 				}
 				if f.Name() == "-" {


### PR DESCRIPTION
Loader should skip symlinks and other irregular files.

closes #1672