### PR TITLE
cue/load/tags: add `arch` to set of injectable system variables

### DIFF
--- a/cmd/cue/cmd/help.go
+++ b/cmd/cue/cmd/help.go
@@ -351,6 +351,13 @@ The following variables are supported:
                 freebsd   illumos   ios       js (wasm)
                 linux     netbsd    openbsd   plan9
                 solaris   windows
+   arch       architecture identifier of the current system. Valid values:
+                386        amd64        amd64p32  arm
+                armbe      arm64        arm64be   loong64
+                mips       mipsle       mips64    mips64le
+                mips64p32  mips64p32le  ppc       ppc64
+                ppc64le    riscv        riscv64   s390
+                s390x      sparc        sparc64   wasm
    cwd        working directory
    username   current username
    hostname   current hostname

--- a/cue/load/tags.go
+++ b/cue/load/tags.go
@@ -58,6 +58,11 @@ func DefaultTagVars() map[string]TagVar {
 				return ast.NewString(runtime.GOOS), nil
 			},
 		},
+		"arch": {
+			Func: func() (ast.Expr, error) {
+				return ast.NewString(runtime.GOARCH), nil
+			},
+		},
 		"cwd": {
 			Func: func() (ast.Expr, error) {
 				return varToString(os.Getwd())


### PR DESCRIPTION
This adds to the set of system-derived variables that are provided iff
the user requests them. It expands the set from 6 to 7, introducing the
variable `arch` as an exact counterpart to the existing `os` variable.

The overhead for providing this is minimal, as the `runtime` package is
already imported and in scope due to the `os` variable.

Adding this variable does not seem to be opening the door to an
expectation that the set of system variables is expandable to meet
individual users' needs. Instead, adding this system variable merely
completes the exposure of the high-level set of variables that are
*already* available to the Go-based consumer, but are not trivially
available to the CLI-based CUE consumer. Of the 2-of-3 variables exposed
by https://pkg.go.dev/runtime#pkg-constants but *not* exposed by CUE,
only `arch` reflects the system on which the CUE CLI is being executed.

The `cue injection` help text has been updated to reflect the full set
of possible values arch values, taken from
https://go.googlesource.com/go/+/ec5170397c724a8ae440b2bc529f857c86f0e6b1/src/go/build/syslist.go#11,
which was the commit that released go1.17 - the currently required CUE
go version in go.mod. This list has been reformatted upstream since
then, but the contents (most recently as at
https://go.googlesource.com/go/+/3c6a5cdb9a29c0e3b12cdaa8ab81ba22d989e3b0/src/go/build/syslist.go#50)
are unchanged.

No tests have been added in this commit. This is for a few reasons:

- the existing `os` variable appears to have no direct tests, so a
  pattern for testing relatively hard-to-mock, machine-specific
  interfaces wasn't available to copy.
- I'm unsure how this would be testable, without the test merely
  becoming a pass-through test of what runtime.GOARCH returns.
- the not-directly-tested nature of the existing `os` variable suggests
  that testing this kind of runtime-derived variable was considered
  non-trivial, non-critical, or both.

Accepting this PR would resolve #1692.

Signed-off-by: Jonathan Matthews <github@hello.jonathanmatthews.com>