### PR TITLE
pkg/net: add Path{E,Une}sape and Query{E,Une}scape

### DIFF
--- a/pkg/net/pkg.go
+++ b/pkg/net/pkg.go
@@ -225,5 +225,53 @@ var pkg = &internal.Package{
 				c.Ret, c.Err = IPString(ip)
 			}
 		},
+	}, {
+		Name: "PathEscape",
+		Params: []internal.Param{
+			{Kind: adt.StringKind},
+		},
+		Result: adt.StringKind,
+		Func: func(c *internal.CallCtxt) {
+			s := c.String(0)
+			if c.Do() {
+				c.Ret = PathEscape(s)
+			}
+		},
+	}, {
+		Name: "PathUnescape",
+		Params: []internal.Param{
+			{Kind: adt.StringKind},
+		},
+		Result: adt.StringKind,
+		Func: func(c *internal.CallCtxt) {
+			s := c.String(0)
+			if c.Do() {
+				c.Ret, c.Err = PathUnescape(s)
+			}
+		},
+	}, {
+		Name: "QueryEscape",
+		Params: []internal.Param{
+			{Kind: adt.StringKind},
+		},
+		Result: adt.StringKind,
+		Func: func(c *internal.CallCtxt) {
+			s := c.String(0)
+			if c.Do() {
+				c.Ret = QueryEscape(s)
+			}
+		},
+	}, {
+		Name: "QueryUnescape",
+		Params: []internal.Param{
+			{Kind: adt.StringKind},
+		},
+		Result: adt.StringKind,
+		Func: func(c *internal.CallCtxt) {
+			s := c.String(0)
+			if c.Do() {
+				c.Ret, c.Err = QueryUnescape(s)
+			}
+		},
 	}},
 }

--- a/pkg/net/testdata/gen.txtar
+++ b/pkg/net/testdata/gen.txtar
@@ -23,6 +23,10 @@ t17: net.ToIP16("127.0.0.1")
 t18: net.IPCIDR("192.168.1.0/24")
 t19: net.IPCIDR("2001:db8:a0b:12f0::1/32")
 t20: net.IPCIDR("172.16.12.3")
+t21: net.PathEscape("foo/bar")
+t22: net.PathUnescape("foo%2Fbar")
+t23: net.QueryEscape("f%o")
+t24: net.QueryUnescape("f%25o")
 -- out/net --
 Errors:
 t9: invalid value "23.23.23.2333" (does not satisfy net.IPv4):
@@ -57,4 +61,8 @@ t17: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 127, 0, 0, 1]
 t18: true
 t19: true
 t20: _|_ // t20: error in call to net.IPCIDR: invalid CIDR address: 172.16.12.3
+t21: "foo%2Fbar"
+t22: "foo/bar"
+t23: "f%25o"
+t24: "f%o"
 

--- a/pkg/net/url.go
+++ b/pkg/net/url.go
@@ -1,0 +1,50 @@
+// Copyright 2019 CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package net
+
+import (
+	"net/url"
+)
+
+// PathEscape escapes the string so it can be safely placed inside a URL path
+// segment, replacing special characters (including /) with %XX sequences as
+// needed.
+func PathEscape(s string) string {
+	return url.PathEscape(s)
+}
+
+// PathUnescape does the inverse transformation of PathEscape, converting each
+// 3-byte encoded substring of the form "%AB" into the hex-decoded byte 0xAB.
+// It returns an error if any % is not followed by two hexadecimal digits.
+//
+// PathUnescape is identical to QueryUnescape except that it does not unescape
+// '+' to ' ' (space).
+func PathUnescape(s string) (string, error) {
+	return url.PathUnescape(s)
+}
+
+// QueryEscape escapes the string so it can be safely placed inside a URL
+// query.
+func QueryEscape(s string) string {
+	return url.QueryEscape(s)
+}
+
+// QueryUnescape does the inverse transformation of QueryEscape, converting
+// each 3-byte encoded substring of the form "%AB" into the hex-decoded byte
+// 0xAB. It returns an error if any % is not followed by two hexadecimal
+// digits.
+func QueryUnescape(s string) (string, error) {
+	return url.QueryUnescape(s)
+}


### PR DESCRIPTION
This adds the following four user functions to the `net` package:

* `PathEscape`
* `PathUnescape`
* `QueryEscape`
* `QueryUnescape`

These functions are identical to the Go std functions by the same name in `net/url`.
In fact, the documentation has been copied from them.
