### PR TITLE
Fix regexp in \s sed in Kubernetes tutorial 

### DIFF
--- a/doc/tutorial/kubernetes/README.md
+++ b/doc/tutorial/kubernetes/README.md
@@ -374,7 +374,7 @@ $ cat <<EOF >> kube.cue
 EOF
 
 # add a file with the component label to each directory
-$ ls -d */ | sed 's/.$//' | xargs -I DIR sh -c 'cd DIR; echo "package kube
+$ ls -d */ | sed 's/$.//' | xargs -I DIR sh -c 'cd DIR; echo "package kube
 
 #Component: \"DIR\"
 " > kube.cue; cd ..'


### PR DESCRIPTION
This PR updates the `regexp` to its intended behaviour. that is to not drop the last character in the folder names. 


```bash 
ls -d */ | sed 's/.$//'                                                   
fronten
infr
kitche
mo
prox
```
=> 

```bash 
$ ls -d */ | sed 's/$.//'                                                 
frontend
infra
kitchen
mon
proxy
```

Closes: #1767 