### PR TITLE
support buildinfo in version sub-command

### DIFF
--- a/cmd/cue/cmd/version.go
+++ b/cmd/cue/cmd/version.go
@@ -15,10 +15,6 @@
 package cmd
 
 import (
-	"fmt"
-	goruntime "runtime"
-	"runtime/debug"
-
 	"github.com/spf13/cobra"
 )
 
@@ -32,9 +28,7 @@ func newVersionCmd(c *Command) *cobra.Command {
 	return cmd
 }
 
-const (
-	defaultVersion = "devel"
-)
+const defaultVersion = "(devel)"
 
 // version be set by a builder using
 // -ldflags='-X cuelang.org/go/cmd/cue/cmd.version=<version>'.
@@ -43,19 +37,4 @@ const (
 // module), in which case the version information is determined
 // from the *debug.BuildInfo (see below). So this mechanism is
 // really considered legacy.
-var (
-	version = defaultVersion
-)
-
-func runVersion(cmd *Command, args []string) error {
-	w := cmd.OutOrStdout()
-	if bi, ok := debug.ReadBuildInfo(); ok && version == defaultVersion {
-		// No specific version provided via version
-		version = bi.Main.Version
-	}
-	fmt.Fprintf(w, "cue version %v %s/%s\n",
-		version,
-		goruntime.GOOS, goruntime.GOARCH,
-	)
-	return nil
-}
+var version = defaultVersion

--- a/cmd/cue/cmd/version_1.18.go
+++ b/cmd/cue/cmd/version_1.18.go
@@ -1,0 +1,97 @@
+// Copyright 2019 CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.18
+
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"runtime/debug"
+	"time"
+
+	"golang.org/x/mod/module"
+)
+
+func runVersion(cmd *Command, args []string) error {
+	w := cmd.OutOrStdout()
+	// read in build info
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		// shouldn't happen
+		return errors.New("unknown error reading build-info")
+	}
+	mod := &bi.Main
+	if mod.Replace != nil {
+		mod = mod.Replace
+	}
+
+	// test-based overrides
+	if v := os.Getenv("CUE_VERSION_TEST_CFG"); v != "" {
+		var extra []debug.BuildSetting
+		if err := json.Unmarshal([]byte(v), &extra); err != nil {
+			return err
+		}
+		bi.Settings = append(bi.Settings, extra...)
+	}
+
+	// prefer ldflags `version` override
+	if version == defaultVersion {
+		// no version provided via ldflags, try buildinfo
+		if bi.Main.Version != "" && bi.Main.Version != defaultVersion {
+			version = bi.Main.Version
+		}
+	}
+
+	if version == defaultVersion {
+		// a specific version was not provided by ldflags or buildInfo
+		// attempt to make our own
+		var vcsTime time.Time
+		var vcsRevision string
+		for _, s := range bi.Settings {
+			switch s.Key {
+			case "vcs.time":
+				// If the format is invalid, we'll print a zero timestamp.
+				vcsTime, _ = time.Parse(time.RFC3339Nano, s.Value)
+			case "vcs.revision":
+				vcsRevision = s.Value
+				if len(vcsRevision) > 12 {
+					vcsRevision = vcsRevision[:12]
+				}
+			}
+		}
+		if vcsRevision != "" {
+			version = module.PseudoVersion("", "", vcsTime, vcsRevision)
+		}
+	}
+
+	fmt.Fprintf(w, "cue version %v\n\n", version)
+	for _, s := range bi.Settings {
+		if s.Value == "" {
+			// skip empty build settings
+			continue
+		}
+		// The padding helps keep readability by aligning:
+		//
+		//   veryverylong.key value
+		//          short.key some-other-value
+		//
+		// Empirically, 16 is enough; the longest key seen is "vcs.revision".
+		fmt.Fprintf(w, "%16s %s\n", s.Key, s.Value)
+	}
+	return nil
+}

--- a/cmd/cue/cmd/version_pre1.18.go
+++ b/cmd/cue/cmd/version_pre1.18.go
@@ -1,0 +1,36 @@
+// Copyright 2019 CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !go1.18
+
+package cmd
+
+import (
+	"fmt"
+	goruntime "runtime"
+	"runtime/debug"
+)
+
+func runVersion(cmd *Command, args []string) error {
+	w := cmd.OutOrStdout()
+	if bi, ok := debug.ReadBuildInfo(); ok && version == defaultVersion {
+		// No specific version provided via version
+		version = bi.Main.Version
+	}
+	fmt.Fprintf(w, "cue version %v %s/%s\n",
+		version,
+		goruntime.GOOS, goruntime.GOARCH,
+	)
+	return nil
+}


### PR DESCRIPTION
Intent of this PR is to include VCS version info as described in #1697. Note that the behavior of the command is unchanged in versions of Go before 1.18, since the embedding of VCS information appeared in Go 1.18.
Fixes #1697

Signed-off-by: Dave Josephsen <djosephsen@fastly.com>