### PR TITLE
fix #1772: EncodeType doesn't unify embedded Go struct with struct definition

### DIFF
--- a/internal/core/convert/go.go
+++ b/internal/core/convert/go.go
@@ -685,16 +685,21 @@ func goTypeToValueRec(ctx *adt.OpContext, allowNullDefault bool, t reflect.Type)
 				}
 				elem = ast.NewBinExpr(token.AND, elem, v)
 			}
-			// TODO: if an identifier starts with __ (or otherwise is not a
-			// valid CUE name), make it a string and create a map to a new
-			// name for references.
 
-			// The GO JSON decoder always allows a value to be undefined.
-			d := &ast.Field{Label: ast.NewIdent(name), Value: elem}
-			if isOptional(&f) {
-				d.Optional = token.Blank.Pos()
+			if name == "" {
+				obj.Elts = append(obj.Elts, &ast.EmbedDecl{Expr: elem})
+			} else {
+				// TODO: if an identifier starts with __ (or otherwise is not a
+				// valid CUE name), make it a string and create a map to a new
+				// name for references.
+
+				// The GO JSON decoder always allows a value to be undefined.
+				d := &ast.Field{Label: ast.NewIdent(name), Value: elem}
+				if isOptional(&f) {
+					d.Optional = token.Blank.Pos()
+				}
+				obj.Elts = append(obj.Elts, d)
 			}
-			obj.Elts = append(obj.Elts, d)
 		}
 
 		// TODO: should we validate references here? Can be done using

--- a/internal/core/convert/go_test.go
+++ b/internal/core/convert/go_test.go
@@ -263,6 +263,11 @@ func TestX(t *testing.T) {
 	t.Error(got)
 }
 
+type EmbeddedObj struct {
+	B int `json:"b"`
+	D string
+}
+
 func TestConvertType(t *testing.T) {
 	testCases := []struct {
 		goTyp interface{}
@@ -369,7 +374,31 @@ func TestConvertType(t *testing.T) {
 	}, {
 		time.Now, // a function
 		"_|_(unsupported Go type (func() time.Time))",
-	}}
+	}, {
+		struct {
+			A           string `json:"a"`
+			EmbeddedObj `json:",inline"`
+			C           string `json:"c,omitempty"`
+		}{},
+		`{
+  a: string
+  {
+    b: ((int & >=-9223372036854775808) & <=9223372036854775807)
+    D: string
+  }
+  c?: string
+}`}, {
+		struct {
+			A string
+			*EmbeddedObj
+		}{},
+		`{
+  A: string
+  (*null|{
+    b: ((int & >=-9223372036854775808) & <=9223372036854775807)
+    D: string
+  })
+}`}}
 
 	r := runtime.New()
 


### PR DESCRIPTION

Signed-off-by: Clare Yang (zhanyang) <zhanyang@cisco.com>