### PR TITLE
spec.md: Fix missing `Slice` and `si_lit` typo

### DIFF
--- a/doc/ref/spec.md
+++ b/doc/ref/spec.md
@@ -293,7 +293,7 @@ There are several kinds of numeric literals.
 int_lit     = decimal_lit | si_lit | octal_lit | binary_lit | hex_lit .
 decimal_lit = "0" | ( "1" … "9" ) { [ "_" ] decimal_digit } .
 decimals    = decimal_digit { [ "_" ] decimal_digit } .
-si_it       = decimals [ "." decimals ] multiplier |
+si_lit      = decimals [ "." decimals ] multiplier |
               "." decimals  multiplier .
 binary_lit  = "0b" binary_digit { binary_digit } .
 hex_lit     = "0" ( "x" | "X" ) hex_digit { [ "_" ] hex_digit } .
@@ -1951,6 +1951,7 @@ PrimaryExpr =
 
 Selector       = "." (identifier | simple_string_lit) .
 Index          = "[" Expression "]" .
+Slice          = "[" [ Expression ] ":" [ Expression ] "]" .
 Argument       = Expression .
 Arguments      = "(" [ ( Argument { "," Argument } ) [ "," ] ] ")" .
 ```


### PR DESCRIPTION
Just something  I ran into while playing around with creating a parser based  on the spec.

Another thing I noticed is  that `decimal_lit` and `decimals` look very much equivalent, or am I missing something?