### PR TITLE
pkg/tool/exec: add .Default() to struct env value

### DIFF
--- a/pkg/tool/exec/exec.go
+++ b/pkg/tool/exec/exec.go
@@ -154,7 +154,7 @@ func mkCommand(ctx *task.Context) (c *exec.Cmd, doc string, err error) {
 	// Struct case.
 	for iter, _ := ctx.Obj.Lookup("env").Fields(); iter.Next(); {
 		label := iter.Label()
-		v := iter.Value()
+		v, _ := iter.Value().Default()
 		var str string
 		switch v.Kind() {
 		case cue.StringKind:

--- a/pkg/tool/exec/exec_test.go
+++ b/pkg/tool/exec/exec_test.go
@@ -36,7 +36,7 @@ func TestEnv(t *testing.T) {
 		env: {
 			WHO:  "World"
 			WHAT: "Hello"
-			WHEN: "Now!"
+			WHEN: *"Now!" | "Never"
 		}
 		`,
 		env: []string{"WHO=World", "WHAT=Hello", "WHEN=Now!"},


### PR DESCRIPTION
Encountered an error that was quite confusing: `invalid environment variable value "perfectly-reasonable-string"`, looking into what caused that I ended up with this little diff.