### PR TITLE
cue/load: Fix the error message on "module root not defined"

### DIFF
--- a/cue/load/import.go
+++ b/cue/load/import.go
@@ -93,7 +93,7 @@ func (l *loader) importPkg(pos token.Pos, p *build.Instance) []*build.Instance {
 	}
 
 	if !strings.HasPrefix(p.Dir, cfg.ModuleRoot) {
-		err := errors.Newf(token.NoPos, "module root not defined", p.DisplayPath)
+		err := errors.Newf(token.NoPos, "module root not defined, provided display path: %s", p.DisplayPath)
 		return retErr(err)
 	}
 


### PR DESCRIPTION
Signed-off-by: Kensei Nakada <handbomusic@gmail.com>

This PR is to fix the following error message. It would be better to add %s to show display path.

```
module root not defined%!(EXTRA string=./basic/user)
```