### PR TITLE
pkg/tool/file: Replace filepath.Glob with doublestar.FilepathGlob

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module cuelang.org/go
 go 1.17
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.2.0
 	github.com/cockroachdb/apd/v2 v2.0.2
 	github.com/emicklei/proto v1.10.0
 	github.com/google/go-cmp v0.5.8

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bmatcuk/doublestar/v4 v4.2.0 h1:Qu+u9wR3Vd89LnlLMHvnZ5coJMWKQamqdz9/p5GNthA=
+github.com/bmatcuk/doublestar/v4 v4.2.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cockroachdb/apd/v2 v2.0.2 h1:weh8u7Cneje73dDh+2tEVLUvyBc89iwepWCD8b8034E=
 github.com/cockroachdb/apd/v2 v2.0.2/go.mod h1:DDxRlzC2lo3/vSlmSoS7JkqbbrARPuFOGr0B9pvN3Gw=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/pkg/tool/file/file.go
+++ b/pkg/tool/file/file.go
@@ -25,6 +25,8 @@ import (
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/errors"
 	"cuelang.org/go/internal/task"
+
+	"github.com/bmatcuk/doublestar/v4"
 )
 
 func init() {
@@ -114,7 +116,8 @@ func (c *cmdGlob) Run(ctx *task.Context) (res interface{}, err error) {
 	if ctx.Err != nil {
 		return nil, ctx.Err
 	}
-	m, err := filepath.Glob(glob)
+
+	m, err := doublestar.FilepathGlob(glob)
 	for i, s := range m {
 		m[i] = filepath.ToSlash(s)
 	}


### PR DESCRIPTION
The Go stdlib implements Glob with Match as its base and does not support the double star syntax. To allow recursive lists via file.Glob it should be supported.

```
command: test: {
	task: {
		list: file.Glob & {
			glob: "charts/bitnami/mysql/**/*.yaml"
		}

		print: cli.Print & {
			text: strings.Join(list.files, "\n")
		}
	}
}
```

Current behaviour:
```
charts/bitnami/mysql/templates/extra-list.yaml
charts/bitnami/mysql/templates/metrics-svc.yaml
charts/bitnami/mysql/templates/networkpolicy.yaml
charts/bitnami/mysql/templates/prometheusrule.yaml
charts/bitnami/mysql/templates/role.yaml
charts/bitnami/mysql/templates/rolebinding.yaml
charts/bitnami/mysql/templates/secrets.yaml
charts/bitnami/mysql/templates/serviceaccount.yaml
charts/bitnami/mysql/templates/servicemonitor.yaml
```

New behaviour:
```
charts/bitnami/mysql/Chart.yaml
charts/bitnami/mysql/values.yaml
charts/bitnami/mysql/templates/extra-list.yaml
charts/bitnami/mysql/templates/metrics-svc.yaml
charts/bitnami/mysql/templates/networkpolicy.yaml
charts/bitnami/mysql/templates/prometheusrule.yaml
charts/bitnami/mysql/templates/role.yaml
charts/bitnami/mysql/templates/rolebinding.yaml
charts/bitnami/mysql/templates/secrets.yaml
charts/bitnami/mysql/templates/serviceaccount.yaml
charts/bitnami/mysql/templates/servicemonitor.yaml
charts/bitnami/mysql/templates/primary/configmap.yaml
charts/bitnami/mysql/templates/primary/initialization-configmap.yaml
charts/bitnami/mysql/templates/primary/pdb.yaml
charts/bitnami/mysql/templates/primary/statefulset.yaml
charts/bitnami/mysql/templates/primary/svc-headless.yaml
charts/bitnami/mysql/templates/primary/svc.yaml
charts/bitnami/mysql/templates/secondary/configmap.yaml
charts/bitnami/mysql/templates/secondary/pdb.yaml
charts/bitnami/mysql/templates/secondary/statefulset.yaml
charts/bitnami/mysql/templates/secondary/svc-headless.yaml
charts/bitnami/mysql/templates/secondary/svc.yaml
```

Fixes #1919 
