### PR TITLE
cue/export/extract: fix comments with comprehensions

### DIFF
--- a/cue/syntax_test.go
+++ b/cue/syntax_test.go
@@ -39,12 +39,28 @@ func TestSyntax(t *testing.T) {
 		in: `
 		// Aloha
 		hello: "world"
+		// Aloha2
+		if true {
+			// Aloha3
+			if true {
+				// Aloha4
+				hello2: "world"
+			}
+		}
 		`,
 		options: o(cue.Docs(true)),
 		out: `
 {
 	// Aloha
 	hello: "world"
+	// Aloha2
+	if true {
+		// Aloha3
+		if true {
+			// Aloha4
+			hello2: "world"
+		}
+	}
 }`,
 	}, {
 		name: "partially resolvable",

--- a/internal/core/compile/compile.go
+++ b/internal/core/compile/compile.go
@@ -730,6 +730,7 @@ func (c *compiler) elem(n ast.Expr) adt.Elem {
 
 func (c *compiler) comprehension(x *ast.Comprehension) adt.Elem {
 	var a []adt.Yielder
+	comments := x.Comments()
 	for _, v := range x.Clauses {
 		switch x := v.(type) {
 		case *ast.ForClause:
@@ -737,6 +738,7 @@ func (c *compiler) comprehension(x *ast.Comprehension) adt.Elem {
 			if x.Key != nil {
 				key = c.label(x.Key)
 			}
+			x.SetComments(comments)
 			y := &adt.ForClause{
 				Syntax: x,
 				Key:    key,
@@ -748,6 +750,7 @@ func (c *compiler) comprehension(x *ast.Comprehension) adt.Elem {
 			a = append(a, y)
 
 		case *ast.IfClause:
+			x.SetComments(comments)
 			y := &adt.IfClause{
 				Src:       x,
 				Condition: c.expr(x.Condition),
@@ -755,6 +758,7 @@ func (c *compiler) comprehension(x *ast.Comprehension) adt.Elem {
 			a = append(a, y)
 
 		case *ast.LetClause:
+			x.SetComments(comments)
 			y := &adt.LetClause{
 				Src:   x,
 				Label: c.label(x.Ident),

--- a/internal/core/export/adt.go
+++ b/internal/core/export/adt.go
@@ -418,8 +418,8 @@ func (e *exporter) decl(env *adt.Environment, d adt.Decl) ast.Decl {
 
 		f.Value = e.expr(env, x.Value)
 		f.Attrs = extractFieldAttrs(nil, x)
+		f.SetComments(x.Src.Comments())
 
-		// extractDocs(nil)
 		return f
 
 	case *adt.OptionalField:
@@ -433,8 +433,8 @@ func (e *exporter) decl(env *adt.Environment, d adt.Decl) ast.Decl {
 
 		f.Value = e.expr(env, x.Value)
 		f.Attrs = extractFieldAttrs(nil, x)
+		f.SetComments(x.Src.Comments())
 
-		// extractDocs(nil)
 		return f
 
 	case *adt.LetField:
@@ -507,10 +507,10 @@ func (e *exporter) decl(env *adt.Environment, d adt.Decl) ast.Decl {
 			alias: alias,
 			field: f,
 		})
-		// extractDocs(nil)
 
 		f.Value = e.expr(env, x.Value)
 		f.Attrs = extractFieldAttrs(nil, x)
+		f.SetComments(x.Src.Comments())
 
 		return f
 
@@ -570,6 +570,7 @@ func (e *exporter) comprehension(env *adt.Environment, comp *adt.Comprehension) 
 			value := e.ident(x.Value)
 			src := e.innerExpr(env, x.Src)
 			clause := &ast.ForClause{Value: value, Source: src}
+			clause.SetComments(ast.Comments(x.Src.Source()))
 			c.Clauses = append(c.Clauses, clause)
 
 			_, saved := e.pushFrame(empty, nil)
@@ -586,6 +587,7 @@ func (e *exporter) comprehension(env *adt.Environment, comp *adt.Comprehension) 
 		case *adt.IfClause:
 			cond := e.innerExpr(env, x.Condition)
 			clause := &ast.IfClause{Condition: cond}
+			clause.SetComments(x.Src.Comments())
 			c.Clauses = append(c.Clauses, clause)
 
 		case *adt.LetClause:
@@ -595,6 +597,7 @@ func (e *exporter) comprehension(env *adt.Environment, comp *adt.Comprehension) 
 				Ident: e.ident(x.Label),
 				Expr:  expr,
 			}
+			clause.SetComments(x.Src.Comments())
 			c.Clauses = append(c.Clauses, clause)
 
 			_, saved := e.pushFrame(empty, nil)

--- a/internal/core/export/extract.go
+++ b/internal/core/export/extract.go
@@ -37,12 +37,16 @@ func extractDocs(v *adt.Vertex, a []adt.Conjunct) (docs []*ast.CommentGroup) {
 
 	// Collect docs directly related to this Vertex.
 	for _, x := range a {
-		if v, ok := x.Elem().(*adt.Vertex); ok {
-			docs = append(docs, extractDocs(v, v.Conjuncts)...)
+		source := x.Source()
+		switch elem := x.Elem().(type) {
+		case *adt.Vertex:
+			docs = append(docs, extractDocs(elem, elem.Conjuncts)...)
 			continue
+		case *adt.Comprehension:
+			source = elem.Value.Source()
 		}
 
-		switch f := x.Source().(type) {
+		switch f := source.(type) {
 		case *ast.Field:
 			if hasShorthandValue(f) {
 				continue

--- a/internal/core/export/testdata/main/adt.txtar
+++ b/internal/core/export/testdata/main/adt.txtar
@@ -53,7 +53,7 @@ l6:   [1, #foo] & {
 n1:  1.0
 n10: 10
 
-// Ignored comment.
+// Not ignored comment.
 
 // t is true
 t: true
@@ -151,6 +151,8 @@ d2: {
 		foo:  C.name
 	}
 }
+
+// Issue #1910
 a: _
 comp: {
 	for k, v in [0] let w = v {
@@ -180,7 +182,13 @@ l6:   [1, #foo] & {
 }
 n1:  1.0
 n10: 10
-t:   true
+
+// Not ignored comment.
+
+// t is true
+t: true
+
+// Dangling comment.
 e1:  <n1
 e2:  >n1 & <n10
 e3:  l4[2]

--- a/internal/core/export/testdata/main/attrs.txtar
+++ b/internal/core/export/testdata/main/attrs.txtar
@@ -163,7 +163,8 @@ dynamicComplex: {
 	[string]: "foo" @step(2)
 	a?:       "foo" @step(3)
 	b?:       "foo" @step(4)
-	if true {}
+	if true // trigger isComplex
+	{}
 }
 dynamicSimple: {
 	a:  "foo" @step(3)

--- a/internal/core/export/testdata/main/docs.txtar
+++ b/internal/core/export/testdata/main/docs.txtar
@@ -43,10 +43,18 @@ baz: bar & {
 	field1: int
 	field2: int
 }
+
+if true {
+	// comment inside of if comprehension
+	field1: int
+}
 -- out.txt --
 -- out/doc --
 []
 - foobar defines at least foo.
+
+[field1]
+- comment inside of if comprehension
 
 [Foo]
 - A Foo fooses stuff.
@@ -107,9 +115,11 @@ Foo: {
 
 // foos are instances of Foo.
 foos: {
-	{
-		[string]: Foo
-	}
+	[string]: Foo
+}
+
+// My first little foo.
+foos: {
 	MyFoo: {
 		// local field comment.
 		field1: 0
@@ -132,6 +142,10 @@ baz: bar & {
 	field1: int
 	field2: int
 }
+if true {
+	// comment inside of if comprehension
+	field1: int
+}
 -- out/value --
 == Simplified
 {
@@ -144,6 +158,8 @@ baz: bar & {
 		// duplicate field comment
 		dup3: int
 	}
+	// comment inside of if comprehension
+	field1: int
 
 	// foos are instances of Foo.
 	foos: {
@@ -187,6 +203,8 @@ baz: bar & {
 		// duplicate field comment
 		dup3: int
 	}
+	// comment inside of if comprehension
+	field1: int
 
 	// foos are instances of Foo.
 	foos: {
@@ -226,6 +244,7 @@ baz: bar & {
 		field2: int
 		dup3:   int
 	}
+	field1: int
 	foos: {
 		MyFoo: {
 			field1: 0
@@ -253,6 +272,8 @@ baz: bar & {
 		// duplicate field comment
 		dup3: int
 	}
+	// comment inside of if comprehension
+	field1: int
 
 	// foos are instances of Foo.
 	foos: {
@@ -292,6 +313,7 @@ baz: bar & {
 		field2: int
 		dup3:   int
 	}
+	field1: int
 	foos: {
 		MyFoo: {
 			field1: 0

--- a/internal/core/export/testdata/main/let.txtar
+++ b/internal/core/export/testdata/main/let.txtar
@@ -316,6 +316,8 @@ y: Y & Y_1
 [unresolvedDisjunction #TypePrimitive "*"]
 [unresolvedDisjunction #TypeBool]
 [unresolvedDisjunction #TypeBool default]
+- `default` sets the default value.
+
 [unresolvedDisjunction #TypeBool _args]
 [unresolvedDisjunction #TypeBool _args required]
 [unresolvedDisjunction #TypeBool Args]

--- a/internal/core/export/testdata/main/shadow.txtar
+++ b/internal/core/export/testdata/main/shadow.txtar
@@ -10,8 +10,8 @@ a: {
 	refs: {
 		Z="y": 1
 		outer: y
-		mid:   X // TODO(unshadow)
-		inner: Z // TODO(unshadow)
+		mid:   X // commentX
+		inner: Z // commentZ
 
 	}
 }
@@ -23,8 +23,8 @@ a: {
 	refs: {
 		y:     1
 		outer: y
-		mid:   X
-		inner: y
+		mid:   X // commentX
+		inner: y // commentZ
 	}
 }
 -- out/doc --

--- a/internal/core/export/testdata/selfcontained/alias.txtar
+++ b/internal/core/export/testdata/selfcontained/alias.txtar
@@ -38,8 +38,13 @@ a: B=b: {
 -- out/default --
 
 {
-	x:     string
-	y:     x
+	x: string
+	y: x
+
+	// TODO: use with non-concrete value. Right now, this causes the reference
+	// above to not shorten (it will point to b, instead of x, as x won't be
+	// reachable).
+	// Reevaluated after value aliases for embeddings are implemented.
 	z:     "string"
 	X=(z): 4
 	Y="y": "foo"


### PR DESCRIPTION
This fixes several comments bugs with comprehensions.

1. Fix the bug that comments lost on comprehensions.

2. Add comments in decl.

Fixes #2062

Signed-off-by: FogDong <dongtianxin.tx@alibaba-inc.com>