### PR TITLE
internal/core/convert: split the cue tag at first comma after last quote

### DIFF
--- a/internal/core/convert/go.go
+++ b/internal/core/convert/go.go
@@ -94,7 +94,7 @@ func parseTag(ctx *adt.OpContext, obj *ast.StructLit, field, tag string) ast.Exp
 
 // splitTag splits a cue tag into cue and options.
 func splitTag(tag string) (cue string, options string) {
-	q := strings.LastIndex(tag, "\"")
+	q := strings.LastIndexByte(tag, '"')
 	if c := strings.Index(tag[q+1:], ","); c >= 0 {
 		return tag[:q+1+c], tag[q+1+c+1:]
 	}

--- a/internal/core/convert/go.go
+++ b/internal/core/convert/go.go
@@ -96,7 +96,7 @@ func parseTag(ctx *adt.OpContext, obj *ast.StructLit, field, tag string) ast.Exp
 func splitTag(tag string) (cue string, options string) {
 	q := strings.LastIndex(tag, "\"")
 	if c := strings.Index(tag[q+1:], ","); c >= 0 {
-		return tag[:c], tag[c+1:]
+		return tag[:q+1+c], tag[q+1+c+1:]
 	}
 	return tag, ""
 }

--- a/internal/core/convert/go.go
+++ b/internal/core/convert/go.go
@@ -95,7 +95,7 @@ func parseTag(ctx *adt.OpContext, obj *ast.StructLit, field, tag string) ast.Exp
 // splitTag splits a cue tag into cue and options.
 func splitTag(tag string) (cue string, options string) {
 	q := strings.LastIndexByte(tag, '"')
-	if c := strings.Index(tag[q+1:], ","); c >= 0 {
+	if c := strings.IndexByte(tag[q+1:], ','); c >= 0 {
 		return tag[:q+1+c], tag[q+1+c+1:]
 	}
 	return tag, ""
@@ -112,7 +112,7 @@ func getName(f *reflect.StructField) string {
 	}
 	for _, s := range tagsWithNames {
 		if tag, ok := f.Tag.Lookup(s); ok {
-			if p := strings.Index(tag, ","); p >= 0 {
+			if p := strings.IndexByte(tag, ','); p >= 0 {
 				tag = tag[:p]
 			}
 			if tag != "" {

--- a/internal/core/convert/go.go
+++ b/internal/core/convert/go.go
@@ -78,9 +78,7 @@ func compileExpr(ctx *adt.OpContext, expr ast.Expr) adt.Value {
 
 // parseTag parses a CUE expression from a cue tag.
 func parseTag(ctx *adt.OpContext, obj *ast.StructLit, field, tag string) ast.Expr {
-	if p := strings.Index(tag, ","); p >= 0 {
-		tag = tag[:p]
-	}
+	tag, _ = splitTag(tag)
 	if tag == "" {
 		return topSentinel
 	}
@@ -92,6 +90,15 @@ func parseTag(ctx *adt.OpContext, obj *ast.StructLit, field, tag string) ast.Exp
 		return &ast.BadExpr{}
 	}
 	return expr
+}
+
+// splitTag splits a cue tag into cue and options.
+func splitTag(tag string) (cue string, options string) {
+	q := strings.LastIndex(tag, "\"")
+	if c := strings.Index(tag[q+1:], ","); c >= 0 {
+		return tag[:c], tag[c+1:]
+	}
+	return tag, ""
 }
 
 // TODO: should we allow mapping names in cue tags? This only seems like a good
@@ -129,8 +136,9 @@ func isOptional(f *reflect.StructField) bool {
 	}
 	if tag, ok := f.Tag.Lookup("cue"); ok {
 		// TODO: only if first field is not empty.
+		_, opt := splitTag(tag)
 		isOptional = false
-		for _, f := range strings.Split(tag, ",")[1:] {
+		for _, f := range strings.Split(opt, ",") {
 			switch f {
 			case "opt":
 				isOptional = true

--- a/internal/core/convert/go_test.go
+++ b/internal/core/convert/go_test.go
@@ -369,6 +369,13 @@ func TestConvertType(t *testing.T) {
 	}, {
 		time.Now, // a function
 		"_|_(unsupported Go type (func() time.Time))",
+	}, {
+		struct {
+			Foobar string `cue:"\"foo,bar\",opt"`
+		}{},
+		`{
+  Foobar?: (string & "foo,bar")
+}`,
 	}}
 
 	r := runtime.New()

--- a/internal/core/convert/go_test.go
+++ b/internal/core/convert/go_test.go
@@ -376,6 +376,13 @@ func TestConvertType(t *testing.T) {
 		`{
   Foobar?: (string & "foo,bar")
 }`,
+	}, {
+		struct {
+			Foobar string `cue:"\"foo,opt,bar\""`
+		}{},
+		`{
+  Foobar: (string & "foo,opt,bar")
+}`,
 	}}
 
 	r := runtime.New()


### PR DESCRIPTION
This fixes a bug when splitting a golang struct tag containing commas.

There are 3 possible ways I can think of to fix this:
1. strip "known" options from the end (currently "opt" and "req") => fragile, we can't know all tags which could be used.
2. find and skip pairs of (not escaped) quotes from the start => complex and not really necessary, see option 3
3. assuming the options won't contain a quote: split at the first comma after the last quote (if any)

This PR implements option 3.

Fixes #1887

Signed-off-by: Alexander Graf <ghostwheel42@users.noreply.github.com>