### PR TITLE
remove redundant Sort call in error list sanitizer

### DIFF
--- a/cue/errors/errors.go
+++ b/cue/errors/errors.go
@@ -442,7 +442,6 @@ func (p list) sanitize() list {
 	}
 	a := make(list, len(p))
 	copy(a, p)
-	a.Sort()
 	a.RemoveMultiples()
 	return a
 }


### PR DESCRIPTION
While looking at error handling code, I noticed that error list is being sorted twice when [searching for duplicates](https://github.com/joomcode/cue/blob/1ce1002dcf8187b2a529275140157de1439685d9/cue/errors/errors.go#L435): [here](https://github.com/joomcode/cue/blob/1ce1002dcf8187b2a529275140157de1439685d9/cue/errors/errors.go#L441) and [once again](https://github.com/joomcode/cue/blob/1ce1002dcf8187b2a529275140157de1439685d9/cue/errors/errors.go#L455) immediately after that. I believe one `Sort()` call is enough.

Signed-off-by: Anton Rychkov <zeithaste@gmail.com>