### PR TITLE
all: correct typos and duplicated words in comments

### DIFF
--- a/cmd/cue/cmd/script_test.go
+++ b/cmd/cue/cmd/script_test.go
@@ -203,7 +203,7 @@ func TestMain(m *testing.M) {
 
 // homeEnvName extracts the logic from os.UserHomeDir to get the
 // name of the environment variable that should be used when
-// seting the user's home directory
+// setting the user's home directory
 func homeEnvName() string {
 	switch goruntime.GOOS {
 	case "windows":

--- a/cue/ast/ast.go
+++ b/cue/ast/ast.go
@@ -488,8 +488,8 @@ type StructLit struct {
 
 // NewStruct creates a struct from the given fields.
 //
-// A field is either a *Field, an *Elipsis, *LetClause, a *CommentGroup, or a
-// Label, optionally followed by a a token.OPTION to indicate the field is
+// A field is either a *Field, an *Ellipsis, *LetClause, a *CommentGroup, or a
+// Label, optionally followed by a token.OPTION to indicate the field is
 // optional, optionally followed by a token.ISA to indicate the field is a
 // definition followed by an expression for the field value.
 //

--- a/cue/load/config.go
+++ b/cue/load/config.go
@@ -250,7 +250,7 @@ type Config struct {
 	// to CUE.
 	DataFiles bool
 
-	// StdRoot specifies an alternative directory for standard libaries.
+	// StdRoot specifies an alternative directory for standard libraries.
 	// This is mostly used for bootstrapping.
 	StdRoot string
 

--- a/cue/load/internal/mvs/mvs.go
+++ b/cue/load/internal/mvs/mvs.go
@@ -437,7 +437,7 @@ List:
 	// requirements of other modules.
 	//
 	// If one of those requirements pulls the version back up above the version
-	// identified by reqs.Previous, then the transitive dependencies of that that
+	// identified by reqs.Previous, then the transitive dependencies of that
 	// initially-downgraded version should no longer matter — in particular, we
 	// should not add new dependencies on module paths that nothing else in the
 	// updated module graph even requires.

--- a/cue/parser/parser.go
+++ b/cue/parser/parser.go
@@ -329,7 +329,7 @@ func (p *parser) consumeCommentGroup(prevLine, n int) (comments *ast.CommentGrou
 
 // Advance to the next non-comment  In the process, collect
 // any comment groups encountered, and refield the last lead and
-// and line comments.
+// line comments.
 //
 // A lead comment is a comment group that starts and ends in a
 // line without any other tokens and that is followed by a non-comment

--- a/cue/types.go
+++ b/cue/types.go
@@ -473,7 +473,7 @@ func (v Value) Uint64() (uint64, error) {
 	return i, nil
 }
 
-// trimZeros trims 0's for better JSON respresentations.
+// trimZeros trims 0's for better JSON representations.
 func trimZeros(s string) string {
 	n1 := len(s)
 	s2 := strings.TrimRight(s, "0")
@@ -1142,7 +1142,7 @@ func (v Value) Pos() token.Pos {
 // TODO: IsFinal: this value can never be changed.
 
 // IsClosed reports whether a list of struct is closed. It reports false when
-// when the value is not a list or struct.
+// the value is not a list or struct.
 //
 // Deprecated: use Allows(AnyString) and Allows(AnyIndex) or Kind/IncompleteKind.
 func (v hiddenValue) IsClosed() bool {
@@ -1820,7 +1820,7 @@ func (v Value) Subsume(w Value, opts ...Option) error {
 //
 // Subsumes reports whether w is an instance of v.
 //
-// Without options, Subsumes checks whether v is a backwards compatbile schema
+// Without options, Subsumes checks whether v is a backwards compatible schema
 // of w.
 //
 // By default, Subsumes tests whether two values are compatible
@@ -2169,7 +2169,7 @@ func Docs(include bool) Option {
 // Definitions indicates whether definitions should be included.
 //
 // Definitions may still be included for certain functions if they are referred
-// to by other other values.
+// to by other values.
 func Definitions(include bool) Option {
 	return func(p *options) {
 		p.hasHidden = true

--- a/encoding/openapi/build.go
+++ b/encoding/openapi/build.go
@@ -403,7 +403,7 @@ func (b *builder) value(v cue.Value, f typeFunc) (isRef bool) {
 
 	if count > 0 { // TODO: implement IsAny.
 		// TODO: perhaps find optimal representation. For now we assume the
-		// representation as is is already optimized for human consumption.
+		// representation as is already optimized for human consumption.
 		if values.IncompleteKind()&cue.StructKind != cue.StructKind && !isRef {
 			values = values.Eval()
 		}

--- a/encoding/openapi/openapi_test.go
+++ b/encoding/openapi/openapi_test.go
@@ -280,7 +280,7 @@ func TestParseDefinitions(t *testing.T) {
 			}
 			if !tc.instanceOnly {
 				t.Run("Value", func(t *testing.T) {
-					// New style call, wih cue.Value
+					// New style call, with cue.Value
 					ctx := cuecontext.New()
 					v := ctx.BuildInstance(inst)
 					if err := v.Err(); err != nil {

--- a/encoding/protobuf/jsonpb/decoder.go
+++ b/encoding/protobuf/jsonpb/decoder.go
@@ -48,7 +48,7 @@ type Option func()
 //	           with/without paddings are accepted.
 //	int:       string values are interpreted as integers
 //	float:     string values are interpreted as numbers, and the values "NaN",
-//	           "Infinity", and "-Infinity" are allowed and converted to
+//	           "Infinity", and "-Infinity" are allowed and converted
 //	           to corresponding error values.
 //	enums:     if a field is of type int and does not have a standard integer
 //	           type for its @protobuf attribute, this is assumed to represent

--- a/internal/core/adt/closed.go
+++ b/internal/core/adt/closed.go
@@ -338,7 +338,7 @@ func Accept(ctx *OpContext, n *Vertex, f Feature) (found, required bool) {
 
 	// TODO(perf): more aggressively determine whether a struct is open or
 	// closed: open structs do not have to be checked, yet they can particularly
-	// be the ones with performance isssues, for instanced as a result of
+	// be the ones with performance issues, for instanced as a result of
 	// embedded for comprehensions.
 	for _, s := range n.Structs {
 		if !s.useForAccept() {

--- a/internal/core/adt/composite.go
+++ b/internal/core/adt/composite.go
@@ -171,7 +171,7 @@ type Vertex struct {
 	// processed.
 	hasAllConjuncts bool
 
-	// isData indicates that this Vertex is to be interepreted as data: pattern
+	// isData indicates that this Vertex is to be interpreted as data: pattern
 	// and additional constraints, as well as optional fields, should be
 	// ignored.
 	isData bool

--- a/internal/core/adt/comprehension.go
+++ b/internal/core/adt/comprehension.go
@@ -49,7 +49,7 @@ package adt
 // With this rewrite, any dependencies in comprehension expressions will follow
 // the same rules, more or less, as with normal evaluation.
 //
-// Note that a singe comprehension may be distributed across multiple fields.
+// Note that a single comprehension may be distributed across multiple fields.
 // The evaluator will ensure, however, that a comprehension is only evaluated
 // once.
 //
@@ -96,7 +96,7 @@ type envYield struct {
 	*envComprehension                // The original comprehension.
 	leaf              *Comprehension // The leaf Comprehension
 
-	// Values specific to the field corresponsing to this envYield
+	// Values specific to the field corresponding to this envYield
 
 	// This envYield was added to selfComprehensions
 	self bool
@@ -270,7 +270,7 @@ type compState struct {
 	state VertexStatus
 }
 
-// yield evaluates a Comprehension within the given Environment and and calls
+// yield evaluates a Comprehension within the given Environment and calls
 // f for each result.
 func (c *OpContext) yield(
 	node *Vertex, // errors are associated with this node

--- a/internal/core/adt/cycle.go
+++ b/internal/core/adt/cycle.go
@@ -245,7 +245,7 @@ type RefNode struct {
 	//      x: b: {Y} | null
 	//
 	// In both cases there are not structural cycles and thus need to be
-	// distinguised from regular structural cycles.
+	// distinguished from regular structural cycles.
 	Node *Vertex
 
 	Next  *RefNode

--- a/internal/core/adt/doc.go
+++ b/internal/core/adt/doc.go
@@ -43,7 +43,7 @@
 // it refers. If the copied value itself contains references we can distinguish
 // two different cases. References that refer to values within the copied
 // reference (not regarding selectors) will henceforth point to the copied node.
-// References that point to outside the referened value will keep referring to
+// References that point to outside the referenced value will keep referring to
 // their original value.
 //
 //	a: b: {

--- a/internal/core/adt/eval.go
+++ b/internal/core/adt/eval.go
@@ -314,7 +314,7 @@ func (c *OpContext) Unify(v *Vertex, state VertexStatus) {
 
 				// TODO: use a more principled form of dereferencing. For instance,
 				// disjuncts could already be assumed to be the given Vertex, and
-				// the the main vertex could be dereferenced during evaluation.
+				// the main vertex could be dereferenced during evaluation.
 				for _, a := range d.Arcs {
 					for _, x := range a.Conjuncts {
 						// All the environments for embedded structs need to be
@@ -382,7 +382,7 @@ func (n *nodeContext) insertConjuncts(state VertexStatus) bool {
 		nInfos := len(n.node.Structs)
 		p := &n.conjuncts[0]
 		n.conjuncts = n.conjuncts[1:]
-		// Intially request a Partial state to allow cyclic references to
+		// Initially request a Partial state to allow cyclic references to
 		// resolve more naturally first. This results in better error messages
 		// and less operations.
 		n.addExprConjunct(*p, Partial)
@@ -920,7 +920,7 @@ type arcKey struct {
 
 // A nodeContext is used to collate all conjuncts of a value to facilitate
 // unification. Conceptually order of unification does not matter. However,
-// order has relevance when performing checks of non-monotic properities. Such
+// order has relevance when performing checks of non-monotic properties. Such
 // checks should only be performed once the full value is known.
 type nodeContext struct {
 	nextFree *nodeContext
@@ -2071,7 +2071,7 @@ func (n *nodeContext) expandOne(state VertexStatus) (done bool) {
 	}
 
 	// No progress, report error later if needed: unification with
-	// disjuncts may resolve this later later on.
+	// disjuncts may resolve this later on.
 	return false
 }
 

--- a/internal/core/adt/expr.go
+++ b/internal/core/adt/expr.go
@@ -250,7 +250,7 @@ func (x *LetField) Source() ast.Node {
 //
 //	[expr]: expr
 type BulkOptionalField struct {
-	Src    *ast.Field // Elipsis or Field
+	Src    *ast.Field // Ellipsis or Field
 	Filter Expr
 	Value  Expr
 	Label  Feature // for reference and formatting
@@ -898,7 +898,7 @@ func (x *LetReference) resolve(ctx *OpContext, state VertexStatus) *Vertex {
 	n := e.Vertex
 
 	// No need to Unify n, as Let references can only result from evaluating
-	// an experssion within n, in which case evaluation must already have
+	// an expression within n, in which case evaluation must already have
 	// started.
 	if n.status < Evaluating {
 		panic("unexpected node state < Evaluating")

--- a/internal/core/dep/dep.go
+++ b/internal/core/dep/dep.go
@@ -250,7 +250,7 @@ func (c *visitor) markResolver(env *adt.Environment, r adt.Resolver) {
 	// It is possible that a reference cannot be resolved because it is
 	// incomplete. In this case, we should check whether subexpressions of the
 	// reference can be resolved to mark those dependencies. For instance,
-	// prefix paths of selectors and the value or index of an index experssion
+	// prefix paths of selectors and the value or index of an index expression
 	// may independently resolve to a valid dependency.
 
 	switch x := r.(type) {

--- a/internal/core/export/export.go
+++ b/internal/core/export/export.go
@@ -131,7 +131,7 @@ func (p *Profile) Def(r adt.Runtime, pkgID string, v *adt.Vertex) (f *ast.File, 
 }
 
 // Expr exports the given unevaluated expression (schema mode).
-// It does not resolve references that point outside the given expession.
+// It does not resolve references that point outside the given expression.
 func Expr(r adt.Runtime, pkgID string, n adt.Expr) (ast.Expr, errors.Error) {
 	return Simplified.Expr(r, pkgID, n)
 }

--- a/internal/core/export/expr.go
+++ b/internal/core/export/expr.go
@@ -357,7 +357,7 @@ func (e *conjuncts) addExpr(env *adt.Environment, src *adt.Vertex, x adt.Elem, i
 			e.attrs = extractDeclAttrs(e.attrs, x.Src)
 		}
 
-		// Only add if it only has no bulk fields or elipsis.
+		// Only add if it only has no bulk fields or ellipsis.
 		if isComplexStruct(x) {
 			_, saved := e.pushFrame(src, nil)
 			e.embed = append(e.embed, e.adt(env, x))

--- a/internal/core/export/label.go
+++ b/internal/core/export/label.go
@@ -56,7 +56,7 @@ func (e *exporter) stringLabel(f adt.Feature) ast.Label {
 //
 // If f is a hidden field that comes from an expanded package, it will mangle
 // the name by expending it with the MD5 hash of the package name. This is to
-// avoid collissions of the hidden identifiers when namespaces are merged.
+// avoid collisions of the hidden identifiers when namespaces are merged.
 // It uses the MD5 hash to allow hidden fields from the same package to
 // still match across inlining and unifications.
 //

--- a/internal/core/export/self.go
+++ b/internal/core/export/self.go
@@ -175,7 +175,7 @@ func (p *pivotter) markDeps(v *adt.Vertex) {
 			// TODO: support marking non-CUE packages as "special". This could
 			// be done, for instance, by marking them as "core" in the runtime
 			// and using a Runtime method to determine whether something is
-			// a core package, rather than relying on the precense of a dot.
+			// a core package, rather than relying on the presence of a dot.
 			path := d.Import().ImportPath.StringValue(p.x.ctx)
 			if !strings.ContainsRune(path, '.') {
 				return nil

--- a/internal/core/runtime/runtime.go
+++ b/internal/core/runtime/runtime.go
@@ -18,7 +18,7 @@ import (
 	"cuelang.org/go/cue/build"
 )
 
-// A Runtime maintains data structures for indexing and resuse for evaluation.
+// A Runtime maintains data structures for indexing and reuse for evaluation.
 type Runtime struct {
 	index *index
 

--- a/internal/cuetest/cuetest.go
+++ b/internal/cuetest/cuetest.go
@@ -71,7 +71,7 @@ var FormatTxtar = os.Getenv(envFormatTxtar) != ""
 // Condition adds support for CUE-specific testscript conditions within
 // testscript scripts. Supported conditions include:
 //
-// [long] - evalutates to true when the long build tag is specified
+// [long] - evaluates to true when the long build tag is specified
 //
 // [golang.org/issue/N] - evaluates to true unless CUE_NON_ISSUES
 // is set to a regexp that matches the condition, i.e. golang.org/issue/N

--- a/internal/encoding/encoder.go
+++ b/internal/encoding/encoder.go
@@ -53,7 +53,7 @@ type Encoder struct {
 // IsConcrete reports whether the output is required to be concrete.
 //
 // INTERNAL ONLY: this is just to work around a problem related to issue #553
-// of catching errors ony after syntax generation, dropping line number
+// of catching errors only after syntax generation, dropping line number
 // information.
 func (e *Encoder) IsConcrete() bool {
 	return e.concrete

--- a/pkg/math/manual.go
+++ b/pkg/math/manual.go
@@ -29,8 +29,8 @@ func roundContext(rounder string) *apd.Context {
 }
 
 // TODO: for now we convert Decimals to int. This allows the desired type to be
-// conveyed. This has the disadvantage tht a number like 1E10000 will need to be
-// expanded. Eventually it would be better to to unify number types and allow
+// conveyed. This has the disadvantage that a number like 1E10000 will need to be
+// expanded. Eventually it would be better to unify number types and allow
 // anything that results in an integer to pose as an integer type.
 func toInt(d *internal.Decimal) *big.Int {
 	i := &d.Coeff

--- a/pkg/net/host.go
+++ b/pkg/net/host.go
@@ -91,7 +91,7 @@ func JoinHostPort(host, port cue.Value) (string, error) {
 	return net.JoinHostPort(hostStr, portStr), nil
 }
 
-// FQDN reports whether is is a valid fully qualified domain name.
+// FQDN reports whether is a valid fully qualified domain name.
 //
 // FQDN allows only ASCII characters as prescribed by RFC 1034 (A-Z, a-z, 0-9
 // and the hyphen).

--- a/pkg/strings/manual.go
+++ b/pkg/strings/manual.go
@@ -54,7 +54,7 @@ func Runes(s string) []rune {
 }
 
 // MinRunes reports whether the number of runes (Unicode codepoints) in a string
-// is at least a certain minimum. MinRunes can be used a a field constraint to
+// is at least a certain minimum. MinRunes can be used a field constraint to
 // except all strings for which this property holds.
 func MinRunes(s string, min int) bool {
 	// TODO: CUE strings cannot be invalid UTF-8. In case this changes, we need
@@ -64,7 +64,7 @@ func MinRunes(s string, min int) bool {
 }
 
 // MaxRunes reports whether the number of runes (Unicode codepoints) in a string
-// exceeds a certain maximum. MaxRunes can be used a a field constraint to
+// exceeds a certain maximum. MaxRunes can be used a field constraint to
 // except all strings for which this property holds
 func MaxRunes(s string, max int) bool {
 	// See comment in MinRunes implementation.


### PR DESCRIPTION
This PR fixes typos and duplicates in the Go comments.