### PR TITLE
correct misleading phrases in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ For more details, see [Installing CUE](./doc/install.md).
 The fastest way to learn the basics is to follow the
 [tutorial on basic language constructs](./doc/tutorial/basics/Readme.md).
 
-A more elaborate tutorial demonstrating of how to convert and restructure
+A more elaborate tutorial demonstrating how to convert and restructure
 an existing set of Kubernetes configurations is available in
 [written form](./doc/tutorial/kubernetes/README.md).
 

--- a/doc/contribute.md
+++ b/doc/contribute.md
@@ -34,7 +34,7 @@ fixing a bug, or considering a new feature.
 * Code contributions, the main focus of this guide. The CUE project is a little
   different from that used by other open source projects so we cover this
 process in more detail below.
-* Contributing thoughts and use cases use cases to proposals. CUE can be and is
+* Contributing thoughts and use cases to proposals. CUE can be and is
   being used in many varied different ways. Sharing experience reports helps
 to shape proposals and designs.
 * Creating content. Whether it be writing blog posts, live streaming,


### PR DESCRIPTION
This change corrects a typo in the file doc/contribute.md, removing
the risk of confusing contributors, especially first-timers.

It also fixes a grammatical error in the README.md file at the root of
the CUE GitHub repository, in the Learning CUE section, which can also
impair the understanding of learners of CUE.