### PR TITLE
cue: decode empty list as empty slice instead of slice-typed nil

### DIFF
--- a/cue/decode.go
+++ b/cue/decode.go
@@ -280,6 +280,9 @@ func (d *decoder) interfaceValue(v Value) (x interface{}) {
 		for list.Next() {
 			a = append(a, d.interfaceValue(list.Value()))
 		}
+		if a == nil {
+			a = []interface{}{}
+		}
 		x = a
 
 	case StructKind:

--- a/cue/decode_test.go
+++ b/cue/decode_test.go
@@ -231,6 +231,10 @@ func TestDecode(t *testing.T) {
 				`,
 		dst: &S{},
 		err: "Decode: x: cannot use value 1 (type int) as (string|bytes)",
+	}, {
+		value: `[]`,
+		dst:   new(interface{}),
+		want:  []interface{}{},
 	}}
 	for _, tc := range testCases {
 		t.Run(tc.value, func(t *testing.T) {


### PR DESCRIPTION
An empty slice and a slice-typed nil have the same behaviour in most cases, but sometimes there are differences.
For example, when marshaling in `json.Marshal`.
From my point of view, it is more correct to return an empty slice for an empty list instead of slice-typed nil.

https://go.dev/play/p/PfVuusup6UO

Source:
```go
package main

import (
	"encoding/json"
	"fmt"
)

func main() {
	var a, b []interface{}
	a = []interface{}{}
	ja, _ := json.Marshal(a)
	jb, _ := json.Marshal(b)
	fmt.Println(string(ja))
	fmt.Println(string(jb))
}
```

Output:
```text
[]
null
```