### PR TITLE
encoding/openapi: add ability to add additional schema constraints

### DIFF
--- a/encoding/openapi/build.go
+++ b/encoding/openapi/build.go
@@ -43,6 +43,7 @@ type buildContext struct {
 	exclusiveBool bool
 	nameFunc      func(inst cue.Value, path cue.Path) string
 	descFunc      func(v cue.Value) string
+	schemasFunc   func(v cue.Value) []SchemaConstraint
 	fieldFilter   *regexp.Regexp
 
 	schemas *OrderedMap
@@ -107,6 +108,7 @@ func schemas(g *Generator, inst cue.InstanceOrValue) (schemas *ast.StructLit, er
 		structural:   g.ExpandReferences,
 		nameFunc:     g.NameFunc,
 		descFunc:     g.DescriptionFunc,
+		schemasFunc:  g.AdditionalSchemasFunc,
 		schemas:      &OrderedMap{},
 		externalRefs: map[string]*externalType{},
 		fieldFilter:  fieldFilter,
@@ -303,6 +305,11 @@ func (b *builder) fillSchema(v cue.Value) *ast.StructLit {
 		}
 	}
 
+	if b.ctx.schemasFunc != nil {
+		for _, attr := range b.ctx.schemasFunc(v) {
+			b.setSingle(attr.Key, attr.Attribute, true)
+		}
+	}
 	schema := b.finish()
 	s := (*ast.StructLit)(schema)
 

--- a/encoding/openapi/build.go
+++ b/encoding/openapi/build.go
@@ -43,7 +43,7 @@ type buildContext struct {
 	exclusiveBool bool
 	nameFunc      func(inst cue.Value, path cue.Path) string
 	descFunc      func(v cue.Value) string
-	schemasFunc   func(v cue.Value) []SchemaConstraint
+	schemasFunc   func(v cue.Value) map[string]ast.Expr
 	fieldFilter   *regexp.Regexp
 
 	schemas *OrderedMap
@@ -306,8 +306,8 @@ func (b *builder) fillSchema(v cue.Value) *ast.StructLit {
 	}
 
 	if b.ctx.schemasFunc != nil {
-		for _, attr := range b.ctx.schemasFunc(v) {
-			b.setSingle(attr.Key, attr.Attribute, true)
+		for k, v := range b.ctx.schemasFunc(v) {
+			b.setSingle(k, v, true)
 		}
 	}
 	schema := b.finish()
@@ -837,7 +837,6 @@ func (b *builder) object(v cue.Value) {
 //     schema: an array instance is valid if at least one element matches
 //     this schema.
 func (b *builder) array(v cue.Value) {
-
 	switch op, a := v.Expr(); op {
 	case cue.CallOp:
 		name := fmt.Sprint(a[0])

--- a/encoding/openapi/openapi.go
+++ b/encoding/openapi/openapi.go
@@ -15,7 +15,6 @@
 package openapi
 
 import (
-	internaljson "cuelang.org/go/internal/encoding/json"
 	"fmt"
 	"strings"
 
@@ -24,6 +23,7 @@ import (
 	"cuelang.org/go/cue/errors"
 	"cuelang.org/go/cue/token"
 	cuejson "cuelang.org/go/encoding/json"
+	internaljson "cuelang.org/go/internal/encoding/json"
 )
 
 // A Config defines options for converting CUE to and from OpenAPI.
@@ -63,7 +63,7 @@ type Config struct {
 	DescriptionFunc func(v cue.Value) string
 
 	// AdditionalSchemasFunc allows adding additional schema constraints for a certain field.
-	AdditionalSchemasFunc func(v cue.Value) []SchemaConstraint
+	AdditionalSchemasFunc func(v cue.Value) map[string]ast.Expr
 
 	// SelfContained causes all non-expanded external references to be included
 	// in this document.
@@ -84,13 +84,6 @@ type Config struct {
 	// OpenAPI Schema. It is an error for an CUE value to refer to itself
 	// if this option is used.
 	ExpandReferences bool
-}
-
-// SchemaConstraint defines a single entry into a schema.
-// An example would be `SchemaConstraint{Key: "minItems", Attribute: 1}`
-type SchemaConstraint struct {
-	Key       string
-	Attribute ast.Expr
 }
 
 type Generator = Config
@@ -147,7 +140,6 @@ func toCUE(name string, x interface{}) (v ast.Expr, err error) {
 			"openapi: could not encode %s", name)
 	}
 	return v, nil
-
 }
 
 func (c *Config) compose(inst cue.InstanceOrValue, schemas *ast.StructLit) (x *ast.StructLit, err error) {

--- a/encoding/openapi/openapi.go
+++ b/encoding/openapi/openapi.go
@@ -15,6 +15,7 @@
 package openapi
 
 import (
+	internaljson "cuelang.org/go/internal/encoding/json"
 	"fmt"
 	"strings"
 
@@ -23,7 +24,6 @@ import (
 	"cuelang.org/go/cue/errors"
 	"cuelang.org/go/cue/token"
 	cuejson "cuelang.org/go/encoding/json"
-	internaljson "cuelang.org/go/internal/encoding/json"
 )
 
 // A Config defines options for converting CUE to and from OpenAPI.
@@ -62,6 +62,9 @@ type Config struct {
 	// the empty string is returned.
 	DescriptionFunc func(v cue.Value) string
 
+	// AdditionalSchemasFunc allows adding additional schema constraints for a certain field.
+	AdditionalSchemasFunc func(v cue.Value) []SchemaConstraint
+
 	// SelfContained causes all non-expanded external references to be included
 	// in this document.
 	SelfContained bool
@@ -81,6 +84,13 @@ type Config struct {
 	// OpenAPI Schema. It is an error for an CUE value to refer to itself
 	// if this option is used.
 	ExpandReferences bool
+}
+
+// SchemaConstraint defines a single entry into a schema.
+// An example would be `SchemaConstraint{Key: "minItems", Attribute: 1}`
+type SchemaConstraint struct {
+	Key       string
+	Attribute ast.Expr
 }
 
 type Generator = Config

--- a/encoding/openapi/openapi_test.go
+++ b/encoding/openapi/openapi_test.go
@@ -22,18 +22,16 @@ import (
 	"strings"
 	"testing"
 
-	"cuelang.org/go/cue/ast"
-	"cuelang.org/go/cue/token"
-	"cuelang.org/go/internal/cuetest"
-
-	"github.com/google/go-cmp/cmp"
-
 	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/ast"
 	"cuelang.org/go/cue/build"
 	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/errors"
 	"cuelang.org/go/cue/load"
+	"cuelang.org/go/cue/token"
 	"cuelang.org/go/encoding/openapi"
+	"cuelang.org/go/internal/cuetest"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestParseDefinitions(t *testing.T) {
@@ -184,13 +182,12 @@ func TestParseDefinitions(t *testing.T) {
 		instanceOnly: true,
 		config: &openapi.Config{
 			Info: info,
-			AdditionalSchemasFunc: func(v cue.Value) []openapi.SchemaConstraint {
+			AdditionalSchemasFunc: func(v cue.Value) map[string]ast.Expr {
 				for _, d := range v.Doc() {
 					if strings.Contains(d.Text(), "validateme") {
-						return []openapi.SchemaConstraint{{
-							Key:       "minItems",
-							Attribute: &ast.BasicLit{Kind: token.INT, ValuePos: token.NoPos, Value: "1"},
-						}}
+						return map[string]ast.Expr{
+							"minItems": &ast.BasicLit{Kind: token.INT, ValuePos: token.NoPos, Value: "1"},
+						}
 					}
 				}
 				return nil
@@ -281,12 +278,12 @@ func TestParseDefinitions(t *testing.T) {
 					walk(all)
 				}
 
-				var out = &bytes.Buffer{}
+				out := &bytes.Buffer{}
 				_ = json.Indent(out, b, "", "   ")
 
 				wantFile := filepath.Join("testdata", tc.out)
 				if cuetest.UpdateGoldenFiles {
-					_ = os.WriteFile(wantFile, out.Bytes(), 0644)
+					_ = os.WriteFile(wantFile, out.Bytes(), 0o644)
 					return
 				}
 
@@ -378,7 +375,7 @@ func TestX(t *testing.T) {
 		t.Fatal(errors.Details(err, nil))
 	}
 
-	var out = &bytes.Buffer{}
+	out := &bytes.Buffer{}
 	_ = json.Indent(out, b, "", "   ")
 	t.Error(out.String())
 }

--- a/encoding/openapi/testdata/additionalschema.cue
+++ b/encoding/openapi/testdata/additionalschema.cue
@@ -1,0 +1,10 @@
+// Note: This example originally derived from a CUE file converted from protobuf.
+
+#HTTPRouteDestination: {
+	headers:     #Headers
+}
+#Headers: {
+	request:  #HeaderOperations
+	// validateme
+	#HeaderOperations:  {}
+}

--- a/encoding/openapi/testdata/additionalschema.json
+++ b/encoding/openapi/testdata/additionalschema.json
@@ -1,0 +1,38 @@
+{
+   "openapi": "3.0.0",
+   "info": {
+      "title": "test",
+      "version": "v1"
+   },
+   "paths": {},
+   "components": {
+      "schemas": {
+         "HTTPRouteDestination": {
+            "type": "object",
+            "required": [
+               "headers"
+            ],
+            "properties": {
+               "headers": {
+                  "$ref": "#/components/schemas/Headers"
+               }
+            }
+         },
+         "Headers": {
+            "type": "object",
+            "required": [
+               "request"
+            ],
+            "properties": {
+               "request": {
+                  "$ref": "#/components/schemas/Headers.HeaderOperations"
+               }
+            }
+         },
+         "Headers.HeaderOperations": {
+            "type": "object",
+            "minItems": 1
+         }
+      }
+   }
+}


### PR DESCRIPTION
This makes https://github.com/cue-lang/cue/discussions/2522 possible. 

Basically we add a Value -> Raw OpenAPI schema. This allows users to add arbitrary addition OpenAPI constraints.

The existing Cue -> OpenAPI validation provides a solid base, but not that many validations can be expressed. This gives full flexibility.

In the PR I added a test that shows an example deriving an additional validation from comments. This showcases a similar implementation to what is seen in [kubebuilder](https://book.kubebuilder.io/reference/markers/crd-validation.html) (which converts Go types to OpenAPI (as k8s CRD, specifically).

----

In our full use case, we have protobuf inputs and want OpenAPI outputs. CEL currently facilitates this through Protobuf -> CEL -> OpenAPI. Currently, our OpenAPI schema is very minimal, as this conversion doesn't have a lot of constraints. We want to add a bunch of constraints; currently we do this through a Kubernetes mutating webhook, but this is operationally complex, so doing it through OpenAPI directly is a big improvement.

The validations we will need to add are quite broad, likely we will be utilizing most of the spec. In addition, we will utilize Kubernetes specific OpenAPI extensions. Most notably, CEL (https://kubernetes.io/docs/reference/using-api/cel/).

Our end goal is to provide something like https://book.kubebuilder.io/reference/markers/crd-validation.html. This is some existing tooling for translating Go types -> OpenAPI. Additional validation constraints are added via comments. We intend to do something similar, just with the source as protobuf types.

---

One consideration is if we derive constraints from protobuf -> openAPI (as done here), or have the constraints encoded as Cue constraints in the intermediary (protobuf constrains -> cue constraints, cue constraints -> openAPI constraints).

The former approach was chosen in this PR for a few reasons:
* Less work, we only need one set of constraints
* Complexity is pushed to users of the library instead of in the core library. The core just provides an extension point. Note that while this is both a Pro and a Con, as users now have to do more work, the [official docs](https://cuelang.org/docs/integrations/openapi/#generate-openapi) already point to the Istio tooling where this will live, so if anyone else is using Cue for CRDs, they likely can pick this up in the same way
* The mapping of Cue<->OpenAPI constraints is not 1:1, so we will not be able to express everything we want). This would likely block our primary use cases which are all custom to Kubernetes.

Some more discussion in slack: https://cuelang.slack.com/archives/CMY132JKY/p1693581326826669