### PR TITLE
Ugly workaround for #2566 issue

### DIFF
--- a/cmd/cue/cmd/testdata/script/stats.txtar
+++ b/cmd/cue/cmd/testdata/script/stats.txtar
@@ -39,6 +39,7 @@ contents overwritten
         "Unifications": 4,
         "Disjuncts": 6,
         "Conjuncts": 8,
+        "Builtins": 0,
         "Freed": 6,
         "Reused": 2,
         "Allocs": 4,
@@ -54,6 +55,7 @@ CUE: {
 	Unifications: 4
 	Disjuncts:    6
 	Conjuncts:    8
+	Builtins:     0
 	Freed:        6
 	Reused:       2
 	Allocs:       4
@@ -68,6 +70,7 @@ CUE:
   Unifications: 4
   Disjuncts: 6
   Conjuncts: 8
+  Builtins: 0
   Freed: 6
   Reused: 2
   Allocs: 4
@@ -81,6 +84,7 @@ Go:
         "Unifications": 4,
         "Disjuncts": 6,
         "Conjuncts": 8,
+        "Builtins": 0,
         "Freed": 6,
         "Reused": 2,
         "Allocs": 4,

--- a/cue/stats/stats.go
+++ b/cue/stats/stats.go
@@ -51,6 +51,10 @@ type Counts struct {
 	// algorithmic behavior.
 	Conjuncts int64
 
+	// Builtins indicates the number of total builtin functions executed (like
+	// `strings.ToLower`).
+	Builtins int64
+
 	// Buffer counters
 	//
 	// Each unification and disjunct operation is associated with an object
@@ -71,6 +75,7 @@ func (c *Counts) Add(other Counts) {
 	c.Unifications += other.Unifications
 	c.Conjuncts += other.Conjuncts
 	c.Disjuncts += other.Disjuncts
+	c.Builtins += other.Builtins
 
 	c.Freed += other.Freed
 	c.Retained += other.Retained
@@ -82,6 +87,7 @@ func (c Counts) Since(start Counts) Counts {
 	c.Unifications -= start.Unifications
 	c.Conjuncts -= start.Conjuncts
 	c.Disjuncts -= start.Disjuncts
+	c.Builtins -= start.Builtins
 
 	c.Freed -= start.Freed
 	c.Retained -= start.Retained
@@ -110,7 +116,8 @@ Retain: {{.Retained}}
 
 Unifications: {{.Unifications}}
 Conjuncts:    {{.Conjuncts}}
-Disjuncts:    {{.Disjuncts}}`))
+Disjuncts:    {{.Disjuncts}}
+Builtins:     {{.Builtins}}`))
 
 func (s Counts) String() string {
 	buf := &strings.Builder{}

--- a/cue/testdata/basicrewrite/000_errors.txtar
+++ b/cue/testdata/basicrewrite/000_errors.txtar
@@ -39,6 +39,7 @@ Retain: 0
 Unifications: 10
 Conjuncts:    14
 Disjuncts:    10
+Builtins:     0
 -- out/eval --
 Errors:
 explicit error (_|_ literal) in source:

--- a/cue/testdata/basicrewrite/001_regexp.txtar
+++ b/cue/testdata/basicrewrite/001_regexp.txtar
@@ -74,6 +74,7 @@ Retain: 0
 Unifications: 16
 Conjuncts:    25
 Disjuncts:    16
+Builtins:     0
 -- out/eval --
 Errors:
 e3: conflicting values !="a" and <5 (mismatched types string and number):

--- a/cue/testdata/basicrewrite/002_arithmetic.txtar
+++ b/cue/testdata/basicrewrite/002_arithmetic.txtar
@@ -103,6 +103,7 @@ Retain: 0
 Unifications: 24
 Conjuncts:    26
 Disjuncts:    24
+Builtins:     0
 -- out/eval --
 Errors:
 divZero: failed arithmetic: division by zero:

--- a/cue/testdata/basicrewrite/003_integer-specific_arithmetic.txtar
+++ b/cue/testdata/basicrewrite/003_integer-specific_arithmetic.txtar
@@ -95,6 +95,7 @@ Retain: 0
 Unifications: 25
 Conjuncts:    25
 Disjuncts:    25
+Builtins:     0
 -- out/eval --
 Errors:
 qe1: invalid operands 2.0 and 1 to 'quo' (type float and int):

--- a/cue/testdata/basicrewrite/004_booleans.txtar
+++ b/cue/testdata/basicrewrite/004_booleans.txtar
@@ -35,6 +35,7 @@ Retain: 0
 Unifications: 4
 Conjuncts:    7
 Disjuncts:    4
+Builtins:     0
 -- out/eval --
 Errors:
 e: conflicting values false and true:

--- a/cue/testdata/basicrewrite/005_boolean_arithmetic.txtar
+++ b/cue/testdata/basicrewrite/005_boolean_arithmetic.txtar
@@ -38,6 +38,7 @@ Retain: 0
 Unifications: 7
 Conjuncts:    9
 Disjuncts:    7
+Builtins:     0
 -- out/eval --
 Errors:
 f: conflicting values false and true:

--- a/cue/testdata/basicrewrite/006_basic_type.txtar
+++ b/cue/testdata/basicrewrite/006_basic_type.txtar
@@ -42,6 +42,7 @@ Retain: 0
 Unifications: 7
 Conjuncts:    13
 Disjuncts:    7
+Builtins:     0
 -- out/eval --
 Errors:
 d: conflicting values int and float (mismatched types int and float):

--- a/cue/testdata/basicrewrite/007_strings_and_bytes.txtar
+++ b/cue/testdata/basicrewrite/007_strings_and_bytes.txtar
@@ -49,6 +49,7 @@ Retain: 0
 Unifications: 9
 Conjuncts:    9
 Disjuncts:    9
+Builtins:     0
 -- out/eval --
 Errors:
 e0: invalid operands "a" and '' to '+' (type string and bytes):

--- a/cue/testdata/basicrewrite/008_escaping.txtar
+++ b/cue/testdata/basicrewrite/008_escaping.txtar
@@ -52,6 +52,7 @@ Retain: 0
 Unifications: 3
 Conjuncts:    4
 Disjuncts:    3
+Builtins:     0
 -- out/eval --
 (struct){
   a: (string){ "foo\nbar" }

--- a/cue/testdata/basicrewrite/009_reference.txtar
+++ b/cue/testdata/basicrewrite/009_reference.txtar
@@ -90,6 +90,7 @@ Retain: 1
 Unifications: 11
 Conjuncts:    13
 Disjuncts:    11
+Builtins:     0
 -- out/eval --
 (struct){
   a: (int){ 2 }

--- a/cue/testdata/basicrewrite/010_lists.txtar
+++ b/cue/testdata/basicrewrite/010_lists.txtar
@@ -84,6 +84,7 @@ Retain: 4
 Unifications: 27
 Conjuncts:    46
 Disjuncts:    26
+Builtins:     0
 -- out/eval --
 Errors:
 e: conflicting values 4 and [] (mismatched types int and list):

--- a/cue/testdata/basicrewrite/011_list_arithmetic.txtar
+++ b/cue/testdata/basicrewrite/011_list_arithmetic.txtar
@@ -55,6 +55,7 @@ Retain: 7
 Unifications: 38
 Conjuncts:    77
 Disjuncts:    38
+Builtins:     0
 -- out/eval --
 Errors:
 e: cannot convert negative number to uint64:

--- a/cue/testdata/basicrewrite/012_selecting.txtar
+++ b/cue/testdata/basicrewrite/012_selecting.txtar
@@ -68,6 +68,7 @@ Retain: 17
 Unifications: 27
 Conjuncts:    35
 Disjuncts:    25
+Builtins:     0
 -- out/eval --
 Errors:
 e: invalid struct selector 4 (type int):

--- a/cue/testdata/basicrewrite/013_obj_unify.txtar
+++ b/cue/testdata/basicrewrite/013_obj_unify.txtar
@@ -83,6 +83,7 @@ Retain: 0
 Unifications: 15
 Conjuncts:    32
 Disjuncts:    15
+Builtins:     0
 -- out/eval --
 Errors:
 e: conflicting values 1 and {a:3} (mismatched types int and struct):

--- a/cue/testdata/basicrewrite/014_disjunctions.txtar
+++ b/cue/testdata/basicrewrite/014_disjunctions.txtar
@@ -89,6 +89,7 @@ Retain: 1
 Unifications: 18
 Conjuncts:    150
 Disjuncts:    135
+Builtins:     0
 -- out/eval --
 (struct){
   o1: (int){ |((int){ 1 }, (int){ 2 }, (int){ 3 }) }

--- a/cue/testdata/basicrewrite/015_types.txtar
+++ b/cue/testdata/basicrewrite/015_types.txtar
@@ -47,6 +47,7 @@ Retain: 0
 Unifications: 10
 Conjuncts:    14
 Disjuncts:    10
+Builtins:     0
 -- out/eval --
 Errors:
 b: invalid operand int ('!' requires concrete value):

--- a/cue/testdata/basicrewrite/016_comparison.txtar
+++ b/cue/testdata/basicrewrite/016_comparison.txtar
@@ -46,6 +46,7 @@ Retain: 0
 Unifications: 9
 Conjuncts:    10
 Disjuncts:    9
+Builtins:     0
 -- out/eval --
 Errors:
 err: invalid operands 2 and "s" to '==' (type int and string):

--- a/cue/testdata/basicrewrite/017_null.txtar
+++ b/cue/testdata/basicrewrite/017_null.txtar
@@ -45,6 +45,7 @@ Retain: 0
 Unifications: 8
 Conjuncts:    9
 Disjuncts:    8
+Builtins:     0
 -- out/eval --
 Errors:
 call: cannot call non-function null (type null):

--- a/cue/testdata/basicrewrite/018_self-reference_cycles.txtar
+++ b/cue/testdata/basicrewrite/018_self-reference_cycles.txtar
@@ -33,6 +33,7 @@ Retain: 11
 Unifications: 6
 Conjuncts:    26
 Disjuncts:    7
+Builtins:     0
 -- out/eval --
 (struct){
   a: (_|_){

--- a/cue/testdata/basicrewrite/019_resolved_self-reference_cycles.txtar
+++ b/cue/testdata/basicrewrite/019_resolved_self-reference_cycles.txtar
@@ -96,6 +96,7 @@ Retain: 4
 Unifications: 18
 Conjuncts:    36
 Disjuncts:    21
+Builtins:     0
 -- out/eval --
 (struct){
   a: (int){ 100 }

--- a/cue/testdata/basicrewrite/020_resolved_self-reference_cycles__Issue_19.txtar
+++ b/cue/testdata/basicrewrite/020_resolved_self-reference_cycles__Issue_19.txtar
@@ -59,6 +59,7 @@ Retain: 3
 Unifications: 6
 Conjuncts:    6
 Disjuncts:    8
+Builtins:     0
 -- out/eval --
 (struct){
   x: (int){ 200 }

--- a/cue/testdata/basicrewrite/aliases/aliases.txtar
+++ b/cue/testdata/basicrewrite/aliases/aliases.txtar
@@ -33,6 +33,7 @@ Retain: 3
 Unifications: 9
 Conjuncts:    14
 Disjuncts:    10
+Builtins:     0
 -- out/eval --
 (struct){
   t0: (struct){

--- a/cue/testdata/benchmarks/chain.txtar
+++ b/cue/testdata/benchmarks/chain.txtar
@@ -2025,6 +2025,7 @@ Retain: 0
 Unifications: 1001
 Conjuncts:    500501
 Disjuncts:    1001
+Builtins:     0
 -- out/eval --
 (struct){
   f1: (string){ string }

--- a/cue/testdata/benchmarks/cycle.txtar
+++ b/cue/testdata/benchmarks/cycle.txtar
@@ -53,6 +53,7 @@ Retain: 1
 Unifications: 15
 Conjuncts:    30
 Disjuncts:    26
+Builtins:     0
 -- out/eval --
 (struct){
   sameValues: (struct){

--- a/cue/testdata/benchmarks/decimal.txtar
+++ b/cue/testdata/benchmarks/decimal.txtar
@@ -49,6 +49,7 @@ Retain: 0
 Unifications: 11
 Conjuncts:    11
 Disjuncts:    11
+Builtins:     0
 -- out/eval --
 (struct){
   out: (#list){

--- a/cue/testdata/benchmarks/deduparc.txtar
+++ b/cue/testdata/benchmarks/deduparc.txtar
@@ -40,6 +40,7 @@ Retain: 0
 Unifications: 7
 Conjuncts:    29
 Disjuncts:    11
+Builtins:     0
 -- out/eval --
 (struct){
   #Value: (#struct){ |((#struct){

--- a/cue/testdata/benchmarks/dedupelem.txtar
+++ b/cue/testdata/benchmarks/dedupelem.txtar
@@ -34,6 +34,7 @@ Retain: 0
 Unifications: 10
 Conjuncts:    94
 Disjuncts:    16
+Builtins:     0
 -- out/eval --
 Errors:
 foo.0: 2 errors in empty disjunction:

--- a/cue/testdata/benchmarks/disjunction.txtar
+++ b/cue/testdata/benchmarks/disjunction.txtar
@@ -155,6 +155,7 @@ Retain: 0
 Unifications: 4
 Conjuncts:    143
 Disjuncts:    82
+Builtins:     0
 -- out/eval --
 (struct){
   x: (struct){

--- a/cue/testdata/benchmarks/issue1684.txtar
+++ b/cue/testdata/benchmarks/issue1684.txtar
@@ -42,6 +42,7 @@ Retain: 0
 Unifications: 791999
 Conjuncts:    2479541
 Disjuncts:    1064043
+Builtins:     0
 -- out/eval --
 (struct){
   #Secret: (#struct){

--- a/cue/testdata/benchmarks/issue2176.txtar
+++ b/cue/testdata/benchmarks/issue2176.txtar
@@ -68,6 +68,7 @@ Retain: 1359
 Unifications: 4161
 Conjuncts:    9489
 Disjuncts:    4804
+Builtins:     573
 -- out/eval --
 (struct){
   #Datastream: (#struct){

--- a/cue/testdata/benchmarks/listdedup.txtar
+++ b/cue/testdata/benchmarks/listdedup.txtar
@@ -42,6 +42,7 @@ Retain: 1
 Unifications: 18724
 Conjuncts:    100730
 Disjuncts:    24097
+Builtins:     0
 -- out/eval --
 (struct){
   A: (#struct){ |((#struct){

--- a/cue/testdata/benchmarks/listdisj.txtar
+++ b/cue/testdata/benchmarks/listdisj.txtar
@@ -64,6 +64,7 @@ Retain: 0
 Unifications: 287
 Conjuncts:    894
 Disjuncts:    447
+Builtins:     0
 -- out/eval --
 (struct){
   #T: (list){

--- a/cue/testdata/benchmarks/mergeddisjunction.txtar
+++ b/cue/testdata/benchmarks/mergeddisjunction.txtar
@@ -50,6 +50,7 @@ Retain: 0
 Unifications: 99
 Conjuncts:    530
 Disjuncts:    283
+Builtins:     0
 -- out/eval --
 (struct){
   list: (#list){

--- a/cue/testdata/benchmarks/sort.txtar
+++ b/cue/testdata/benchmarks/sort.txtar
@@ -93,6 +93,7 @@ Retain: 1
 Unifications: 7529
 Conjuncts:    12154
 Disjuncts:    7530
+Builtins:     2
 -- out/eval --
 (struct){
   _a: (#list){

--- a/cue/testdata/builtins/056_issue314.txtar
+++ b/cue/testdata/builtins/056_issue314.txtar
@@ -85,6 +85,7 @@ Retain: 17
 Unifications: 45
 Conjuncts:    77
 Disjuncts:    62
+Builtins:     16
 -- out/eval --
 (struct){
   x: (#struct){

--- a/cue/testdata/builtins/all.txtar
+++ b/cue/testdata/builtins/all.txtar
@@ -26,6 +26,7 @@ Retain: 2
 Unifications: 14
 Conjuncts:    17
 Disjuncts:    14
+Builtins:     2
 -- out/eval --
 Errors:
 fatalArg.x: invalid operands "eee" and 'eee' to '+' (type string and bytes):

--- a/cue/testdata/builtins/and.txtar
+++ b/cue/testdata/builtins/and.txtar
@@ -13,6 +13,7 @@ Retain: 2
 Unifications: 6
 Conjuncts:    13
 Disjuncts:    6
+Builtins:     2
 -- out/eval --
 Errors:
 embed.#x: conflicting values 2 and 1:

--- a/cue/testdata/builtins/closed.txtar
+++ b/cue/testdata/builtins/closed.txtar
@@ -51,6 +51,7 @@ Retain: 40
 Unifications: 185
 Conjuncts:    365
 Disjuncts:    190
+Builtins:     19
 -- out/eval --
 Errors:
 b.x: field not allowed:

--- a/cue/testdata/builtins/incomplete.txtar
+++ b/cue/testdata/builtins/incomplete.txtar
@@ -110,6 +110,7 @@ Retain: 53
 Unifications: 109
 Conjuncts:    266
 Disjuncts:    156
+Builtins:     32
 -- out/eval --
 Errors:
 badListType.decimal: cannot use 2 (type int) as list in argument 1 to list.Max:

--- a/cue/testdata/builtins/intdiv.txtar
+++ b/cue/testdata/builtins/intdiv.txtar
@@ -48,6 +48,7 @@ Retain: 0
 Unifications: 29
 Conjuncts:    29
 Disjuncts:    29
+Builtins:     28
 -- out/eval --
 Errors:
 quoDivByZero: division by zero:

--- a/cue/testdata/builtins/issue299.txtar
+++ b/cue/testdata/builtins/issue299.txtar
@@ -14,6 +14,7 @@ Retain: 0
 Unifications: 2
 Conjuncts:    5
 Disjuncts:    3
+Builtins:     0
 -- out/eval --
 Errors:
 x: invalid value ["x","x"] (does not satisfy list.UniqueItems):

--- a/cue/testdata/builtins/issue490.txtar
+++ b/cue/testdata/builtins/issue490.txtar
@@ -17,6 +17,7 @@ Retain: 2
 Unifications: 10
 Conjuncts:    14
 Disjuncts:    10
+Builtins:     2
 -- out/eval --
 Errors:
 B.c: field not allowed:

--- a/cue/testdata/builtins/list/issue332.txtar
+++ b/cue/testdata/builtins/list/issue332.txtar
@@ -22,6 +22,7 @@ Retain: 12
 Unifications: 25
 Conjuncts:    65
 Disjuncts:    35
+Builtins:     2
 -- out/eval --
 (struct){
   #d: (#struct){

--- a/cue/testdata/builtins/list/sort.txtar
+++ b/cue/testdata/builtins/list/sort.txtar
@@ -12,6 +12,7 @@ Retain: 2
 Unifications: 20
 Conjuncts:    33
 Disjuncts:    22
+Builtins:     1
 -- out/eval --
 (struct){
   a: (#list){

--- a/cue/testdata/builtins/validators.txtar
+++ b/cue/testdata/builtins/validators.txtar
@@ -124,6 +124,7 @@ Retain: 0
 Unifications: 50
 Conjuncts:    91
 Disjuncts:    52
+Builtins:     2
 -- out/eval --
 Errors:
 callOfCallToValidator.e: cannot call previously called validator b:

--- a/cue/testdata/choosedefault/000_pick_first.txtar
+++ b/cue/testdata/choosedefault/000_pick_first.txtar
@@ -55,6 +55,7 @@ Retain: 0
 Unifications: 6
 Conjuncts:    11
 Disjuncts:    11
+Builtins:     0
 -- out/eval --
 (struct){
   a: ((bool|int|string)){ |(*(int){ 5 }, (string){ "a" }, (bool){ true }) }

--- a/cue/testdata/choosedefault/001_simple_disambiguation_conflict.txtar
+++ b/cue/testdata/choosedefault/001_simple_disambiguation_conflict.txtar
@@ -29,6 +29,7 @@ Retain: 0
 Unifications: 4
 Conjuncts:    17
 Disjuncts:    14
+Builtins:     0
 -- out/eval --
 (struct){
   a: (string){ |(*(string){ "a" }, (string){ "b" }) }

--- a/cue/testdata/choosedefault/002_associativity_of_defaults.txtar
+++ b/cue/testdata/choosedefault/002_associativity_of_defaults.txtar
@@ -46,6 +46,7 @@ Retain: 0
 Unifications: 11
 Conjuncts:    93
 Disjuncts:    83
+Builtins:     0
 -- out/eval --
 (struct){
   a: (string){ |(*(string){ "a" }, (string){ "b" }, (string){ "c" }) }

--- a/cue/testdata/compile/alias.txtar
+++ b/cue/testdata/compile/alias.txtar
@@ -38,6 +38,7 @@ Retain: 2
 Unifications: 10
 Conjuncts:    11
 Disjuncts:    10
+Builtins:     0
 -- out/eval --
 (struct){
   dynamic: (struct){

--- a/cue/testdata/compile/fields.txtar
+++ b/cue/testdata/compile/fields.txtar
@@ -21,6 +21,7 @@ Retain: 0
 Unifications: 5
 Conjuncts:    5
 Disjuncts:    5
+Builtins:     0
 -- out/eval --
 (struct){
   #dev: (int){ int }

--- a/cue/testdata/compile/files.txtar
+++ b/cue/testdata/compile/files.txtar
@@ -36,6 +36,7 @@ Retain: 0
 Unifications: 4
 Conjuncts:    7
 Disjuncts:    4
+Builtins:     0
 -- out/eval --
 (struct){
   a: (#list){

--- a/cue/testdata/compile/json.txtar
+++ b/cue/testdata/compile/json.txtar
@@ -44,6 +44,7 @@ Retain: 0
 Unifications: 11
 Conjuncts:    11
 Disjuncts:    11
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/compile/scope.txtar
+++ b/cue/testdata/compile/scope.txtar
@@ -87,6 +87,7 @@ Retain: 8
 Unifications: 50
 Conjuncts:    102
 Disjuncts:    54
+Builtins:     0
 -- out/eval --
 Errors:
 schema.next: structural cycle

--- a/cue/testdata/comprehensions/015_list_comprehension.txtar
+++ b/cue/testdata/comprehensions/015_list_comprehension.txtar
@@ -90,6 +90,7 @@ Retain: 10
 Unifications: 19
 Conjuncts:    36
 Disjuncts:    23
+Builtins:     0
 -- out/eval --
 (struct){
   a: (#list){

--- a/cue/testdata/comprehensions/045_comprehension_and_skipped_field.txtar
+++ b/cue/testdata/comprehensions/045_comprehension_and_skipped_field.txtar
@@ -59,6 +59,7 @@ Retain: 7
 Unifications: 8
 Conjuncts:    11
 Disjuncts:    12
+Builtins:     0
 -- out/eval --
 (struct){
   x: (struct){

--- a/cue/testdata/comprehensions/checkdefined.txtar
+++ b/cue/testdata/comprehensions/checkdefined.txtar
@@ -87,6 +87,7 @@ Retain: 26
 Unifications: 100
 Conjuncts:    134
 Disjuncts:    105
+Builtins:     1
 -- out/eval --
 (struct){
   xc: (#struct){

--- a/cue/testdata/comprehensions/closed.txtar
+++ b/cue/testdata/comprehensions/closed.txtar
@@ -100,6 +100,7 @@ Retain: 3
 Unifications: 58
 Conjuncts:    103
 Disjuncts:    71
+Builtins:     0
 -- out/eval --
 Errors:
 disallowed.vErr.d: field not allowed:

--- a/cue/testdata/comprehensions/errors.txtar
+++ b/cue/testdata/comprehensions/errors.txtar
@@ -53,6 +53,7 @@ Retain: 1
 Unifications: 19
 Conjuncts:    40
 Disjuncts:    29
+Builtins:     0
 -- out/eval --
 Errors:
 conflictRangingOverSelf.x.age: conflicting values int and "age" (mismatched types int and string):

--- a/cue/testdata/comprehensions/fields.txtar
+++ b/cue/testdata/comprehensions/fields.txtar
@@ -67,6 +67,7 @@ Retain: 1
 Unifications: 33
 Conjuncts:    41
 Disjuncts:    33
+Builtins:     5
 -- out/eval --
 (struct){
   dynamic: (struct){

--- a/cue/testdata/comprehensions/for.txtar
+++ b/cue/testdata/comprehensions/for.txtar
@@ -22,6 +22,7 @@ Retain: 7
 Unifications: 18
 Conjuncts:    18
 Disjuncts:    21
+Builtins:     0
 -- out/eval --
 Errors:
 k: invalid operand e (found int, want list or struct):

--- a/cue/testdata/comprehensions/iferror.txtar
+++ b/cue/testdata/comprehensions/iferror.txtar
@@ -156,6 +156,7 @@ Retain: 14
 Unifications: 33
 Conjuncts:    66
 Disjuncts:    57
+Builtins:     0
 -- out/eval --
 Errors:
 issue1972.err1: conflicting values [] and {someCondition:_,patchs:[...{}],patchs,if someCondition {patchs:_}} (mismatched types list and struct):

--- a/cue/testdata/comprehensions/incomplete.txtar
+++ b/cue/testdata/comprehensions/incomplete.txtar
@@ -15,6 +15,7 @@ Retain: 0
 Unifications: 7
 Conjuncts:    7
 Disjuncts:    7
+Builtins:     0
 -- out/eval --
 (struct){
   cond: (bool){ bool }

--- a/cue/testdata/comprehensions/issue1732.txtar
+++ b/cue/testdata/comprehensions/issue1732.txtar
@@ -131,6 +131,7 @@ Retain: 10
 Unifications: 111
 Conjuncts:    249
 Disjuncts:    126
+Builtins:     0
 -- out/eval --
 (struct){
   networkingv1: (struct){

--- a/cue/testdata/comprehensions/issue2171.txtar
+++ b/cue/testdata/comprehensions/issue2171.txtar
@@ -30,6 +30,7 @@ Retain: 0
 Unifications: 3
 Conjuncts:    5
 Disjuncts:    3
+Builtins:     0
 -- out/eval --
 (struct){
   do: (struct){

--- a/cue/testdata/comprehensions/issue2481.txtar
+++ b/cue/testdata/comprehensions/issue2481.txtar
@@ -80,6 +80,7 @@ Retain: 58
 Unifications: 26
 Conjuncts:    50
 Disjuncts:    56
+Builtins:     0
 -- out/eval --
 Errors:
 out: cannot combine regular field "val" with "b":

--- a/cue/testdata/comprehensions/issue287.txtar
+++ b/cue/testdata/comprehensions/issue287.txtar
@@ -17,6 +17,7 @@ Retain: 2
 Unifications: 5
 Conjuncts:    7
 Disjuncts:    5
+Builtins:     0
 -- out/eval --
 (struct){
   #E: (#struct){

--- a/cue/testdata/comprehensions/issue293.txtar
+++ b/cue/testdata/comprehensions/issue293.txtar
@@ -34,6 +34,7 @@ Retain: 3
 Unifications: 14
 Conjuncts:    25
 Disjuncts:    15
+Builtins:     2
 -- out/eval --
 Errors:
 z.x.f2: field not allowed:

--- a/cue/testdata/comprehensions/issue436.txtar
+++ b/cue/testdata/comprehensions/issue436.txtar
@@ -29,6 +29,7 @@ Retain: 0
 Unifications: 13
 Conjuncts:    44
 Disjuncts:    25
+Builtins:     0
 -- out/eval --
 (struct){
   #a: (#struct){

--- a/cue/testdata/comprehensions/issue507.txtar
+++ b/cue/testdata/comprehensions/issue507.txtar
@@ -33,6 +33,7 @@ Retain: 0
 Unifications: 11
 Conjuncts:    17
 Disjuncts:    15
+Builtins:     0
 -- out/eval --
 (struct){
   somelist: (list){ |(*(#list){

--- a/cue/testdata/comprehensions/issue837.txtar
+++ b/cue/testdata/comprehensions/issue837.txtar
@@ -73,6 +73,7 @@ Retain: 123
 Unifications: 107
 Conjuncts:    295
 Disjuncts:    240
+Builtins:     0
 -- out/eval --
 Errors:
 #Configure.service.description.role: undefined field: role:

--- a/cue/testdata/comprehensions/issue843.txtar
+++ b/cue/testdata/comprehensions/issue843.txtar
@@ -50,6 +50,7 @@ Retain: 14
 Unifications: 52
 Conjuncts:    120
 Disjuncts:    66
+Builtins:     0
 -- out/eval --
 (struct){
   #d1: (#struct){

--- a/cue/testdata/comprehensions/lists.txtar
+++ b/cue/testdata/comprehensions/lists.txtar
@@ -12,6 +12,7 @@ Retain: 0
 Unifications: 7
 Conjuncts:    8
 Disjuncts:    7
+Builtins:     0
 -- out/eval --
 Errors:
 a.1.b: conflicting values 3 and 2:

--- a/cue/testdata/comprehensions/multi.txtar
+++ b/cue/testdata/comprehensions/multi.txtar
@@ -31,6 +31,7 @@ Retain: 0
 Unifications: 24
 Conjuncts:    37
 Disjuncts:    24
+Builtins:     0
 -- out/eval --
 (struct){
   list: (#list){

--- a/cue/testdata/comprehensions/nested.txtar
+++ b/cue/testdata/comprehensions/nested.txtar
@@ -68,6 +68,7 @@ Retain: 33
 Unifications: 35
 Conjuncts:    95
 Disjuncts:    75
+Builtins:     0
 -- out/eval --
 (struct){
   service: (struct){

--- a/cue/testdata/comprehensions/nested2.txtar
+++ b/cue/testdata/comprehensions/nested2.txtar
@@ -105,6 +105,7 @@ Retain: 4
 Unifications: 43
 Conjuncts:    74
 Disjuncts:    43
+Builtins:     0
 -- out/eval --
 (struct){
   given: (struct){

--- a/cue/testdata/comprehensions/nestembed.txtar
+++ b/cue/testdata/comprehensions/nestembed.txtar
@@ -27,6 +27,7 @@ Retain: 0
 Unifications: 18
 Conjuncts:    26
 Disjuncts:    18
+Builtins:     4
 -- out/eval --
 (struct){
   DeleteThis: (#list){

--- a/cue/testdata/comprehensions/pushdown.txtar
+++ b/cue/testdata/comprehensions/pushdown.txtar
@@ -751,6 +751,7 @@ Retain: 108
 Unifications: 395
 Conjuncts:    640
 Disjuncts:    472
+Builtins:     2
 -- out/eval --
 Errors:
 embed.fail1.p: field not allowed:

--- a/cue/testdata/cycle/015_reference_across_tuples_and_back.txtar
+++ b/cue/testdata/cycle/015_reference_across_tuples_and_back.txtar
@@ -56,6 +56,7 @@ Retain: 8
 Unifications: 7
 Conjuncts:    12
 Disjuncts:    12
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/cycle/021_delayed_constraint_failure.txtar
+++ b/cue/testdata/cycle/021_delayed_constraint_failure.txtar
@@ -34,6 +34,7 @@ Retain: 1
 Unifications: 4
 Conjuncts:    5
 Disjuncts:    4
+Builtins:     0
 -- out/eval --
 Errors:
 b: conflicting values 210 and 200:

--- a/cue/testdata/cycle/023_reentrance.txtar
+++ b/cue/testdata/cycle/023_reentrance.txtar
@@ -72,6 +72,7 @@ Retain: 148
 Unifications: 196
 Conjuncts:    464
 Disjuncts:    268
+Builtins:     0
 -- out/eval --
 Errors:
 structural cycle:

--- a/cue/testdata/cycle/025_cannot_resolve_references_that_would_be_ambiguous.txtar
+++ b/cue/testdata/cycle/025_cannot_resolve_references_that_would_be_ambiguous.txtar
@@ -63,6 +63,7 @@ Retain: 19
 Unifications: 24
 Conjuncts:    80
 Disjuncts:    52
+Builtins:     0
 -- out/eval --
 (struct){
   a1: (_|_){

--- a/cue/testdata/cycle/049_self-reference_cycles_conflicts_with_strings.txtar
+++ b/cue/testdata/cycle/049_self-reference_cycles_conflicts_with_strings.txtar
@@ -36,6 +36,7 @@ Retain: 1
 Unifications: 4
 Conjuncts:    5
 Disjuncts:    5
+Builtins:     0
 -- out/eval --
 Errors:
 a.x: conflicting values "hey!?" and "hey":

--- a/cue/testdata/cycle/050_resolved_self-reference_cycles_with_disjunctions.txtar
+++ b/cue/testdata/cycle/050_resolved_self-reference_cycles_with_disjunctions.txtar
@@ -53,6 +53,7 @@ Retain: 0
 Unifications: 25
 Conjuncts:    64
 Disjuncts:    43
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){ |((struct){

--- a/cue/testdata/cycle/051_resolved_self-reference_cycles_with_disjunction.txtar
+++ b/cue/testdata/cycle/051_resolved_self-reference_cycles_with_disjunction.txtar
@@ -177,6 +177,7 @@ Retain: 24
 Unifications: 31
 Conjuncts:    128
 Disjuncts:    60
+Builtins:     0
 -- out/eval --
 Errors:
 xe3: conflicting values 7 and 6:

--- a/cue/testdata/cycle/052_resolved_self-reference_cycles_with_disjunction_with_defaults.txtar
+++ b/cue/testdata/cycle/052_resolved_self-reference_cycles_with_disjunction_with_defaults.txtar
@@ -134,6 +134,7 @@ Retain: 25
 Unifications: 27
 Conjuncts:    82
 Disjuncts:    58
+Builtins:     0
 -- out/eval --
 Errors:
 xe3: conflicting values 7 and 6:

--- a/cue/testdata/cycle/builtins.txtar
+++ b/cue/testdata/cycle/builtins.txtar
@@ -78,6 +78,7 @@ Retain: 34
 Unifications: 37
 Conjuncts:    53
 Disjuncts:    61
+Builtins:     6
 -- out/eval --
 (struct){
   builtinCyclePerm0: (struct){

--- a/cue/testdata/cycle/chain.txtar
+++ b/cue/testdata/cycle/chain.txtar
@@ -217,6 +217,7 @@ Retain: 185
 Unifications: 800
 Conjuncts:    3175
 Disjuncts:    1974
+Builtins:     11
 -- out/eval --
 (struct){
   chain: (struct){

--- a/cue/testdata/cycle/compbottom.txtar
+++ b/cue/testdata/cycle/compbottom.txtar
@@ -264,6 +264,7 @@ Retain: 200
 Unifications: 85
 Conjuncts:    126
 Disjuncts:    194
+Builtins:     10
 -- out/eval --
 (struct){
   simple: (struct){

--- a/cue/testdata/cycle/compbottom2.txtar
+++ b/cue/testdata/cycle/compbottom2.txtar
@@ -272,6 +272,7 @@ Retain: 73
 Unifications: 151
 Conjuncts:    158
 Disjuncts:    202
+Builtins:     0
 -- out/eval --
 (struct){
   self: (struct){

--- a/cue/testdata/cycle/compbottomnofinal.txtar
+++ b/cue/testdata/cycle/compbottomnofinal.txtar
@@ -366,6 +366,7 @@ Retain: 302
 Unifications: 115
 Conjuncts:    223
 Disjuncts:    215
+Builtins:     7
 -- out/eval --
 (struct){
   minimal: (struct){

--- a/cue/testdata/cycle/comprehension.txtar
+++ b/cue/testdata/cycle/comprehension.txtar
@@ -319,6 +319,7 @@ Retain: 145
 Unifications: 832
 Conjuncts:    2525
 Disjuncts:    1404
+Builtins:     48
 -- out/eval --
 Errors:
 selfReferential.insertionError.A: field foo3 not allowed by earlier comprehension or reference cycle

--- a/cue/testdata/cycle/constraints.txtar
+++ b/cue/testdata/cycle/constraints.txtar
@@ -443,6 +443,7 @@ Retain: 4
 Unifications: 143
 Conjuncts:    321
 Disjuncts:    147
+Builtins:     0
 -- out/eval --
 Errors:
 mutuallyTriggeringCycle.t1.x.c.b.b.b.b: structural cycle

--- a/cue/testdata/cycle/cycle_with_bounds.txtar
+++ b/cue/testdata/cycle/cycle_with_bounds.txtar
@@ -29,6 +29,7 @@ Retain: 1
 Unifications: 4
 Conjuncts:    9
 Disjuncts:    4
+Builtins:     0
 -- out/eval --
 (struct){
   #Value: (int){ int }

--- a/cue/testdata/cycle/disjunction.txtar
+++ b/cue/testdata/cycle/disjunction.txtar
@@ -45,6 +45,7 @@ Retain: 0
 Unifications: 33
 Conjuncts:    73
 Disjuncts:    73
+Builtins:     0
 -- out/eval --
 Errors:
 cycle.a: structural cycle

--- a/cue/testdata/cycle/evaluate.txtar
+++ b/cue/testdata/cycle/evaluate.txtar
@@ -116,6 +116,7 @@ Retain: 126
 Unifications: 135
 Conjuncts:    269
 Disjuncts:    156
+Builtins:     18
 -- out/eval --
 Errors:
 closeCycle.a: structural cycle

--- a/cue/testdata/cycle/expression.txtar
+++ b/cue/testdata/cycle/expression.txtar
@@ -105,6 +105,7 @@ Retain: 71
 Unifications: 58
 Conjuncts:    410
 Disjuncts:    75
+Builtins:     0
 -- out/eval --
 (struct){
   t1: (struct){

--- a/cue/testdata/cycle/inline.txtar
+++ b/cue/testdata/cycle/inline.txtar
@@ -162,6 +162,7 @@ Retain: 834
 Unifications: 388
 Conjuncts:    1307
 Disjuncts:    707
+Builtins:     0
 -- out/eval --
 Errors:
 structural cycle:

--- a/cue/testdata/cycle/inline_non_recursive.txtar
+++ b/cue/testdata/cycle/inline_non_recursive.txtar
@@ -69,6 +69,7 @@ Retain: 1047
 Unifications: 680
 Conjuncts:    2709
 Disjuncts:    1414
+Builtins:     18
 -- out/eval --
 (struct){
   ok1: (struct){

--- a/cue/testdata/cycle/issue241.txtar
+++ b/cue/testdata/cycle/issue241.txtar
@@ -33,6 +33,7 @@ Retain: 7
 Unifications: 11
 Conjuncts:    101
 Disjuncts:    47
+Builtins:     0
 -- out/eval --
 (struct){
   #Value: (int){ |((int){ 0 }, (int){ 1 }) }

--- a/cue/testdata/cycle/issue242.txtar
+++ b/cue/testdata/cycle/issue242.txtar
@@ -96,6 +96,7 @@ Retain: 18
 Unifications: 26
 Conjuncts:    181
 Disjuncts:    82
+Builtins:     0
 -- out/eval --
 (struct){
   #size: (int){ 2 }

--- a/cue/testdata/cycle/issue306.txtar
+++ b/cue/testdata/cycle/issue306.txtar
@@ -13,6 +13,7 @@ Retain: 0
 Unifications: 5
 Conjuncts:    5
 Disjuncts:    5
+Builtins:     0
 -- out/eval --
 Errors:
 #Controller.settings.controller: structural cycle

--- a/cue/testdata/cycle/issue429.txtar
+++ b/cue/testdata/cycle/issue429.txtar
@@ -58,6 +58,7 @@ Retain: 12
 Unifications: 40
 Conjuncts:    150
 Disjuncts:    101
+Builtins:     0
 -- out/eval --
 Errors:
 er3.min: 2 errors in empty disjunction:

--- a/cue/testdata/cycle/issue494.txtar
+++ b/cue/testdata/cycle/issue494.txtar
@@ -33,6 +33,7 @@ Retain: 0
 Unifications: 43
 Conjuncts:    83
 Disjuncts:    45
+Builtins:     7
 -- out/eval --
 Errors:
 f.ben: incompatible list lengths (1 and 2)

--- a/cue/testdata/cycle/issue502.txtar
+++ b/cue/testdata/cycle/issue502.txtar
@@ -39,6 +39,7 @@ Retain: 0
 Unifications: 93
 Conjuncts:    264
 Disjuncts:    93
+Builtins:     0
 -- out/eval --
 (struct){
   #T: (#struct){

--- a/cue/testdata/cycle/issue990.txtar
+++ b/cue/testdata/cycle/issue990.txtar
@@ -182,6 +182,7 @@ Retain: 26
 Unifications: 2588
 Conjuncts:    12056
 Disjuncts:    3258
+Builtins:     0
 -- out/eval --
 (struct){
   #AC: (#struct){

--- a/cue/testdata/cycle/patterns.txtar
+++ b/cue/testdata/cycle/patterns.txtar
@@ -19,6 +19,7 @@ Retain: 2
 Unifications: 7
 Conjuncts:    59
 Disjuncts:    9
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/cycle/self.txtar
+++ b/cue/testdata/cycle/self.txtar
@@ -272,6 +272,7 @@ Retain: 27
 Unifications: 236
 Conjuncts:    686
 Disjuncts:    439
+Builtins:     0
 -- out/eval --
 Errors:
 expr.error1.a: conflicting values 4 and 3:

--- a/cue/testdata/cycle/structural.txtar
+++ b/cue/testdata/cycle/structural.txtar
@@ -546,6 +546,7 @@ Retain: 61
 Unifications: 629
 Conjuncts:    1224
 Disjuncts:    847
+Builtins:     3
 -- out/eval --
 Errors:
 a1.f.0: structural cycle

--- a/cue/testdata/cycle/with_defaults.txtar
+++ b/cue/testdata/cycle/with_defaults.txtar
@@ -22,6 +22,7 @@ Retain: 0
 Unifications: 10
 Conjuncts:    22
 Disjuncts:    16
+Builtins:     0
 -- out/eval --
 (struct){
   range1: (struct){

--- a/cue/testdata/definitions/026_combined_definitions.txtar
+++ b/cue/testdata/definitions/026_combined_definitions.txtar
@@ -126,6 +126,7 @@ Retain: 1
 Unifications: 29
 Conjuncts:    41
 Disjuncts:    30
+Builtins:     0
 -- out/eval --
 Errors:
 #D4.env.b: field not allowed:

--- a/cue/testdata/definitions/028_recursive_closing_starting_at_non-definition.txtar
+++ b/cue/testdata/definitions/028_recursive_closing_starting_at_non-definition.txtar
@@ -81,6 +81,7 @@ Retain: 0
 Unifications: 14
 Conjuncts:    21
 Disjuncts:    14
+Builtins:     0
 -- out/eval --
 (struct){
   z: (struct){

--- a/cue/testdata/definitions/032_definitions_with_embedding.txtar
+++ b/cue/testdata/definitions/032_definitions_with_embedding.txtar
@@ -89,6 +89,7 @@ Retain: 0
 Unifications: 20
 Conjuncts:    36
 Disjuncts:    20
+Builtins:     0
 -- out/eval --
 Errors:
 #e1.a.d: field not allowed:

--- a/cue/testdata/definitions/033_Issue_#153.txtar
+++ b/cue/testdata/definitions/033_Issue_#153.txtar
@@ -70,6 +70,7 @@ Retain: 1
 Unifications: 11
 Conjuncts:    23
 Disjuncts:    16
+Builtins:     0
 -- out/eval --
 Errors:
 listOfCloseds.0.b: field not allowed:

--- a/cue/testdata/definitions/036_closing_with_failed_optional.txtar
+++ b/cue/testdata/definitions/036_closing_with_failed_optional.txtar
@@ -107,6 +107,7 @@ Retain: 1
 Unifications: 24
 Conjuncts:    43
 Disjuncts:    29
+Builtins:     0
 -- out/eval --
 (struct){
   #k1: (#struct){

--- a/cue/testdata/definitions/036_optionals_in_open_structs.txtar
+++ b/cue/testdata/definitions/036_optionals_in_open_structs.txtar
@@ -65,6 +65,7 @@ Retain: 0
 Unifications: 6
 Conjuncts:    17
 Disjuncts:    6
+Builtins:     0
 -- out/eval --
 (struct){
   A: (struct){

--- a/cue/testdata/definitions/037_closing_with_comprehensions.txtar
+++ b/cue/testdata/definitions/037_closing_with_comprehensions.txtar
@@ -112,6 +112,7 @@ Retain: 10
 Unifications: 28
 Conjuncts:    43
 Disjuncts:    28
+Builtins:     0
 -- out/eval --
 Errors:
 #E.f3: field not allowed:

--- a/cue/testdata/definitions/037_conjunction_of_optional_sets.txtar
+++ b/cue/testdata/definitions/037_conjunction_of_optional_sets.txtar
@@ -60,6 +60,7 @@ Retain: 0
 Unifications: 9
 Conjuncts:    29
 Disjuncts:    9
+Builtins:     0
 -- out/eval --
 Errors:
 c.aaa: field not allowed:

--- a/cue/testdata/definitions/038_continue_recursive_closing_for_optionals.txtar
+++ b/cue/testdata/definitions/038_continue_recursive_closing_for_optionals.txtar
@@ -46,6 +46,7 @@ Retain: 0
 Unifications: 6
 Conjuncts:    9
 Disjuncts:    6
+Builtins:     0
 -- out/eval --
 Errors:
 a.v.b: field not allowed:

--- a/cue/testdata/definitions/039_augment_closed_optionals.txtar
+++ b/cue/testdata/definitions/039_augment_closed_optionals.txtar
@@ -92,6 +92,7 @@ Retain: 0
 Unifications: 9
 Conjuncts:    35
 Disjuncts:    9
+Builtins:     0
 -- out/eval --
 (struct){
   #A: (#struct){

--- a/cue/testdata/definitions/comprehensions.txtar
+++ b/cue/testdata/definitions/comprehensions.txtar
@@ -19,6 +19,7 @@ Retain: 0
 Unifications: 6
 Conjuncts:    6
 Disjuncts:    6
+Builtins:     0
 -- out/eval --
 Errors:
 issue595.files: undefined field: nam:

--- a/cue/testdata/definitions/defembed.txtar
+++ b/cue/testdata/definitions/defembed.txtar
@@ -16,6 +16,7 @@ Retain: 1
 Unifications: 6
 Conjuncts:    9
 Disjuncts:    7
+Builtins:     0
 -- out/eval --
 Errors:
 a.c: field not allowed:

--- a/cue/testdata/definitions/dynamic.txtar
+++ b/cue/testdata/definitions/dynamic.txtar
@@ -24,6 +24,7 @@ Retain: 1
 Unifications: 19
 Conjuncts:    29
 Disjuncts:    23
+Builtins:     0
 -- out/eval --
 (struct){
   #A: (#struct){

--- a/cue/testdata/definitions/embed.txtar
+++ b/cue/testdata/definitions/embed.txtar
@@ -83,6 +83,7 @@ Retain: 6
 Unifications: 59
 Conjuncts:    124
 Disjuncts:    69
+Builtins:     0
 -- out/eval --
 Errors:
 reclose1.z.d: field not allowed:

--- a/cue/testdata/definitions/files.txtar
+++ b/cue/testdata/definitions/files.txtar
@@ -36,6 +36,7 @@ Retain: 1
 Unifications: 21
 Conjuncts:    69
 Disjuncts:    26
+Builtins:     0
 -- out/eval --
 (#struct){
   #theme: (#struct){

--- a/cue/testdata/definitions/hidden.txtar
+++ b/cue/testdata/definitions/hidden.txtar
@@ -40,6 +40,7 @@ Retain: 2
 Unifications: 30
 Conjuncts:    40
 Disjuncts:    31
+Builtins:     0
 -- out/eval --
 Errors:
 e._name.c: field not allowed:

--- a/cue/testdata/definitions/issue271.txtar
+++ b/cue/testdata/definitions/issue271.txtar
@@ -16,6 +16,7 @@ Retain: 2
 Unifications: 8
 Conjuncts:    18
 Disjuncts:    8
+Builtins:     2
 -- out/eval --
 Errors:
 x.b: field not allowed:

--- a/cue/testdata/definitions/issue317.txtar
+++ b/cue/testdata/definitions/issue317.txtar
@@ -45,6 +45,7 @@ Retain: 0
 Unifications: 46
 Conjuncts:    122
 Disjuncts:    52
+Builtins:     0
 -- out/eval --
 (struct){
   #T: (#struct){

--- a/cue/testdata/definitions/issue320.txtar
+++ b/cue/testdata/definitions/issue320.txtar
@@ -20,6 +20,7 @@ Retain: 1
 Unifications: 7
 Conjuncts:    14
 Disjuncts:    8
+Builtins:     0
 -- out/eval --
 Errors:
 foo.y: field not allowed:

--- a/cue/testdata/definitions/issue342.txtar
+++ b/cue/testdata/definitions/issue342.txtar
@@ -37,6 +37,7 @@ Retain: 2
 Unifications: 18
 Conjuncts:    33
 Disjuncts:    24
+Builtins:     0
 -- out/eval --
 (struct){
   X: (struct){

--- a/cue/testdata/definitions/issue359.txtar
+++ b/cue/testdata/definitions/issue359.txtar
@@ -44,6 +44,7 @@ Retain: 0
 Unifications: 41
 Conjuncts:    134
 Disjuncts:    81
+Builtins:     0
 -- out/eval --
 (struct){
   #simple: (#struct){

--- a/cue/testdata/definitions/issue367.txtar
+++ b/cue/testdata/definitions/issue367.txtar
@@ -14,6 +14,7 @@ Retain: 0
 Unifications: 17
 Conjuncts:    36
 Disjuncts:    17
+Builtins:     0
 -- out/eval --
 (struct){
   #def1: (#struct){

--- a/cue/testdata/definitions/issue370.txtar
+++ b/cue/testdata/definitions/issue370.txtar
@@ -29,6 +29,7 @@ Retain: 0
 Unifications: 11
 Conjuncts:    27
 Disjuncts:    11
+Builtins:     0
 -- out/eval --
 (struct){
   #C1: (#struct){

--- a/cue/testdata/definitions/issue419.txtar
+++ b/cue/testdata/definitions/issue419.txtar
@@ -24,6 +24,7 @@ Retain: 0
 Unifications: 13
 Conjuncts:    25
 Disjuncts:    17
+Builtins:     0
 -- out/eval --
 (struct){
   #A: (#struct){

--- a/cue/testdata/definitions/issue471.txtar
+++ b/cue/testdata/definitions/issue471.txtar
@@ -32,6 +32,7 @@ Retain: 2
 Unifications: 18
 Conjuncts:    31
 Disjuncts:    22
+Builtins:     0
 -- out/eval --
 (struct){
   #a: (#struct){ |((#struct){

--- a/cue/testdata/definitions/issue483.txtar
+++ b/cue/testdata/definitions/issue483.txtar
@@ -19,6 +19,7 @@ Retain: 3
 Unifications: 14
 Conjuncts:    35
 Disjuncts:    17
+Builtins:     0
 -- out/eval --
 (struct){
   out: (#struct){

--- a/cue/testdata/definitions/issue491.txtar
+++ b/cue/testdata/definitions/issue491.txtar
@@ -44,6 +44,7 @@ Retain: 1
 Unifications: 29
 Conjuncts:    71
 Disjuncts:    46
+Builtins:     0
 -- out/eval --
 (struct){
   #Prestep: (#struct){

--- a/cue/testdata/definitions/issue493.txtar
+++ b/cue/testdata/definitions/issue493.txtar
@@ -20,6 +20,7 @@ Retain: 0
 Unifications: 20
 Conjuncts:    38
 Disjuncts:    24
+Builtins:     0
 -- out/eval --
 (struct){
   #Artifact: (#struct){

--- a/cue/testdata/definitions/issue496.txtar
+++ b/cue/testdata/definitions/issue496.txtar
@@ -18,6 +18,7 @@ Retain: 0
 Unifications: 8
 Conjuncts:    13
 Disjuncts:    8
+Builtins:     0
 -- out/eval --
 (struct){
   #A: (_){ _ }

--- a/cue/testdata/definitions/issue497.txtar
+++ b/cue/testdata/definitions/issue497.txtar
@@ -18,6 +18,7 @@ Retain: 0
 Unifications: 10
 Conjuncts:    15
 Disjuncts:    10
+Builtins:     0
 -- out/eval --
 (struct){
   #A: (_){ _ }

--- a/cue/testdata/definitions/issue533.txtar
+++ b/cue/testdata/definitions/issue533.txtar
@@ -28,6 +28,7 @@ Retain: 0
 Unifications: 11
 Conjuncts:    17
 Disjuncts:    11
+Builtins:     0
 -- out/eval --
 Errors:
 x1.Age: field not allowed:

--- a/cue/testdata/definitions/issue539.txtar
+++ b/cue/testdata/definitions/issue539.txtar
@@ -22,6 +22,7 @@ Retain: 0
 Unifications: 10
 Conjuncts:    18
 Disjuncts:    14
+Builtins:     0
 -- out/eval --
 (struct){
   #Schema: (#struct){

--- a/cue/testdata/definitions/list.txtar
+++ b/cue/testdata/definitions/list.txtar
@@ -15,6 +15,7 @@ Retain: 1
 Unifications: 9
 Conjuncts:    14
 Disjuncts:    10
+Builtins:     0
 -- out/eval --
 (struct){
   c: (#struct){

--- a/cue/testdata/definitions/visibility.txtar
+++ b/cue/testdata/definitions/visibility.txtar
@@ -19,6 +19,7 @@ Retain: 0
 Unifications: 8
 Conjuncts:    10
 Disjuncts:    8
+Builtins:     0
 -- out/eval --
 (struct){
   #foo: (#struct){

--- a/cue/testdata/disjunctions/019_ips.txtar
+++ b/cue/testdata/disjunctions/019_ips.txtar
@@ -64,6 +64,7 @@ Retain: 6
 Unifications: 48
 Conjuncts:    111
 Disjuncts:    60
+Builtins:     0
 -- out/eval --
 (struct){
   IP: (#list){

--- a/cue/testdata/disjunctions/defembed.txtar
+++ b/cue/testdata/disjunctions/defembed.txtar
@@ -37,6 +37,7 @@ Retain: 0
 Unifications: 52
 Conjuncts:    373
 Disjuncts:    306
+Builtins:     0
 -- out/eval --
 (struct){
   x: (struct){

--- a/cue/testdata/disjunctions/elimination.txtar
+++ b/cue/testdata/disjunctions/elimination.txtar
@@ -497,6 +497,7 @@ Retain: 115
 Unifications: 1260
 Conjuncts:    3417
 Disjuncts:    2454
+Builtins:     0
 -- out/eval --
 Errors:
 issue2209.full.Bar.resource.spec: 6 errors in empty disjunction:

--- a/cue/testdata/disjunctions/embed.txtar
+++ b/cue/testdata/disjunctions/embed.txtar
@@ -70,6 +70,7 @@ Retain: 1
 Unifications: 257
 Conjuncts:    478
 Disjuncts:    417
+Builtins:     0
 -- out/eval --
 (struct){
   default: (struct){

--- a/cue/testdata/disjunctions/errors.txtar
+++ b/cue/testdata/disjunctions/errors.txtar
@@ -41,6 +41,7 @@ Retain: 0
 Unifications: 28
 Conjuncts:    56
 Disjuncts:    40
+Builtins:     0
 -- out/eval --
 Errors:
 issue516.x: 2 errors in empty disjunction:

--- a/cue/testdata/disjunctions/incomplete.txtar
+++ b/cue/testdata/disjunctions/incomplete.txtar
@@ -59,6 +59,7 @@ Retain: 0
 Unifications: 40
 Conjuncts:    99
 Disjuncts:    70
+Builtins:     8
 -- out/eval --
 (struct){
   issue700: (struct){

--- a/cue/testdata/disjunctions/operands.txtar
+++ b/cue/testdata/disjunctions/operands.txtar
@@ -46,6 +46,7 @@ Retain: 0
 Unifications: 22
 Conjuncts:    33
 Disjuncts:    30
+Builtins:     0
 -- out/eval --
 (struct){
   list: (list){ |(*(#list){

--- a/cue/testdata/disjunctions/specdeviation.txtar
+++ b/cue/testdata/disjunctions/specdeviation.txtar
@@ -71,6 +71,7 @@ Retain: 2
 Unifications: 28
 Conjuncts:    217
 Disjuncts:    172
+Builtins:     0
 -- out/eval --
 (struct){
   Q: (int){ |(*(int){ 1 }, (int){ int }) }

--- a/cue/testdata/eval/basictypes.txtar
+++ b/cue/testdata/eval/basictypes.txtar
@@ -20,6 +20,7 @@ Retain: 0
 Unifications: 9
 Conjuncts:    14
 Disjuncts:    9
+Builtins:     0
 -- out/eval --
 (struct){
   top: (struct){

--- a/cue/testdata/eval/bounds.txtar
+++ b/cue/testdata/eval/bounds.txtar
@@ -72,6 +72,7 @@ Retain: 1
 Unifications: 53
 Conjuncts:    90
 Disjuncts:    54
+Builtins:     0
 -- out/eval --
 Errors:
 simplifyExpr.e2: cannot use null for bound >:

--- a/cue/testdata/eval/bulk.txtar
+++ b/cue/testdata/eval/bulk.txtar
@@ -79,6 +79,7 @@ Retain: 12
 Unifications: 63
 Conjuncts:    126
 Disjuncts:    90
+Builtins:     0
 -- out/eval --
 Errors:
 t1.c.z: field not allowed:

--- a/cue/testdata/eval/closed_disjunction.txtar
+++ b/cue/testdata/eval/closed_disjunction.txtar
@@ -23,6 +23,7 @@ Retain: 0
 Unifications: 34
 Conjuncts:    60
 Disjuncts:    46
+Builtins:     0
 -- out/eval --
 Errors:
 b: 2 errors in empty disjunction:

--- a/cue/testdata/eval/closedness.txtar
+++ b/cue/testdata/eval/closedness.txtar
@@ -52,6 +52,7 @@ Retain: 0
 Unifications: 26
 Conjuncts:    39
 Disjuncts:    26
+Builtins:     0
 -- out/eval --
 Errors:
 a.q.e: field not allowed:

--- a/cue/testdata/eval/comprehensions.txtar
+++ b/cue/testdata/eval/comprehensions.txtar
@@ -107,6 +107,7 @@ Retain: 19
 Unifications: 68
 Conjuncts:    96
 Disjuncts:    81
+Builtins:     1
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/eval/conflicts.txtar
+++ b/cue/testdata/eval/conflicts.txtar
@@ -27,6 +27,7 @@ Retain: 0
 Unifications: 15
 Conjuncts:    23
 Disjuncts:    15
+Builtins:     0
 -- out/eval --
 Errors:
 t0.v: conflicting values int and string (mismatched types int and string):

--- a/cue/testdata/eval/conjuncts.txtar
+++ b/cue/testdata/eval/conjuncts.txtar
@@ -78,6 +78,7 @@ Retain: 22
 Unifications: 45
 Conjuncts:    135
 Disjuncts:    86
+Builtins:     0
 -- out/eval --
 Errors:
 issue2351.let.param: conflicting values "foo" and [{}] (mismatched types string and list):

--- a/cue/testdata/eval/cycles_ref.txtar
+++ b/cue/testdata/eval/cycles_ref.txtar
@@ -17,6 +17,7 @@ Retain: 3
 Unifications: 12
 Conjuncts:    24
 Disjuncts:    15
+Builtins:     0
 -- out/eval --
 (struct){
   a: (int){ 200 }

--- a/cue/testdata/eval/discontinuous.txtar
+++ b/cue/testdata/eval/discontinuous.txtar
@@ -58,6 +58,7 @@ Retain: 9
 Unifications: 14
 Conjuncts:    23
 Disjuncts:    23
+Builtins:     0
 -- out/eval --
 (struct){
   a: (#list){

--- a/cue/testdata/eval/disjunctions.txtar
+++ b/cue/testdata/eval/disjunctions.txtar
@@ -142,6 +142,7 @@ Retain: 0
 Unifications: 147
 Conjuncts:    564
 Disjuncts:    304
+Builtins:     0
 -- out/eval --
 Errors:
 f: 2 errors in empty disjunction:

--- a/cue/testdata/eval/dynamic_field.txtar
+++ b/cue/testdata/eval/dynamic_field.txtar
@@ -80,6 +80,7 @@ Retain: 11
 Unifications: 61
 Conjuncts:    77
 Disjuncts:    66
+Builtins:     0
 -- out/eval --
 Errors:
 invalid interpolation: conflicting values 2 and 1:

--- a/cue/testdata/eval/embed.txtar
+++ b/cue/testdata/eval/embed.txtar
@@ -35,6 +35,7 @@ Retain: 1
 Unifications: 16
 Conjuncts:    32
 Disjuncts:    17
+Builtins:     0
 -- out/eval --
 (struct){
   #A: (#struct){

--- a/cue/testdata/eval/errunifiy.txtar
+++ b/cue/testdata/eval/errunifiy.txtar
@@ -16,6 +16,7 @@ Retain: 5
 Unifications: 8
 Conjuncts:    14
 Disjuncts:    8
+Builtins:     5
 -- out/eval --
 Errors:
 explicit error (_|_ literal) in source:

--- a/cue/testdata/eval/expressions.txtar
+++ b/cue/testdata/eval/expressions.txtar
@@ -13,6 +13,7 @@ Retain: 0
 Unifications: 5
 Conjuncts:    5
 Disjuncts:    5
+Builtins:     0
 -- out/eval --
 (struct){
   a: (int){ 1 }

--- a/cue/testdata/eval/fields.txtar
+++ b/cue/testdata/eval/fields.txtar
@@ -35,6 +35,7 @@ Retain: 0
 Unifications: 7
 Conjuncts:    9
 Disjuncts:    7
+Builtins:     0
 -- out/eval --
 Errors:
 bulkToSelf.a.foo.bar: conflicting values "3" and int (mismatched types string and int):

--- a/cue/testdata/eval/incomplete.txtar
+++ b/cue/testdata/eval/incomplete.txtar
@@ -53,6 +53,7 @@ Retain: 101
 Unifications: 32
 Conjuncts:    159
 Disjuncts:    50
+Builtins:     0
 -- out/eval --
 (struct){
   s: (string){ string }

--- a/cue/testdata/eval/insertion.txtar
+++ b/cue/testdata/eval/insertion.txtar
@@ -105,6 +105,7 @@ Retain: 23
 Unifications: 61
 Conjuncts:    151
 Disjuncts:    66
+Builtins:     0
 -- out/eval --
 (struct){
   embeddingDirect: (struct){

--- a/cue/testdata/eval/issue2146.txtar
+++ b/cue/testdata/eval/issue2146.txtar
@@ -49,6 +49,7 @@ Retain: 18
 Unifications: 173
 Conjuncts:    557
 Disjuncts:    189
+Builtins:     0
 -- out/eval --
 (struct){
   p1: (struct){

--- a/cue/testdata/eval/issue2235.txtar
+++ b/cue/testdata/eval/issue2235.txtar
@@ -109,6 +109,7 @@ Retain: 72
 Unifications: 104
 Conjuncts:    271
 Disjuncts:    161
+Builtins:     9
 -- out/eval --
 (struct){
   shorewallParams: (#struct){

--- a/cue/testdata/eval/issue2550.txtar
+++ b/cue/testdata/eval/issue2550.txtar
@@ -26,6 +26,7 @@ Retain: 5
 Unifications: 5
 Conjuncts:    5
 Disjuncts:    9
+Builtins:     1
 -- out/eval --
 (_|_){
   // [incomplete] undefined field: missing:

--- a/cue/testdata/eval/issue285.txtar
+++ b/cue/testdata/eval/issue285.txtar
@@ -19,6 +19,7 @@ Retain: 0
 Unifications: 10
 Conjuncts:    23
 Disjuncts:    10
+Builtins:     0
 -- out/eval --
 (struct){
   #TopLevel: (#struct){

--- a/cue/testdata/eval/issue295.txtar
+++ b/cue/testdata/eval/issue295.txtar
@@ -23,6 +23,7 @@ Retain: 1
 Unifications: 4
 Conjuncts:    7
 Disjuncts:    4
+Builtins:     1
 -- out/eval --
 (struct){
   p: (#struct){

--- a/cue/testdata/eval/issue349.txtar
+++ b/cue/testdata/eval/issue349.txtar
@@ -19,6 +19,7 @@ Retain: 0
 Unifications: 10
 Conjuncts:    10
 Disjuncts:    10
+Builtins:     0
 -- out/eval --
 (struct){
   ex: (struct){

--- a/cue/testdata/eval/issue353.txtar
+++ b/cue/testdata/eval/issue353.txtar
@@ -21,6 +21,7 @@ Retain: 0
 Unifications: 11
 Conjuncts:    21
 Disjuncts:    15
+Builtins:     0
 -- out/eval --
 (struct){
   e: (#struct){ |((#struct){

--- a/cue/testdata/eval/issue494.txtar
+++ b/cue/testdata/eval/issue494.txtar
@@ -24,6 +24,7 @@ Retain: 0
 Unifications: 26
 Conjuncts:    56
 Disjuncts:    28
+Builtins:     4
 -- out/eval --
 (struct){
   _Q: (#list){

--- a/cue/testdata/eval/issue500.txtar
+++ b/cue/testdata/eval/issue500.txtar
@@ -29,6 +29,7 @@ Retain: 22
 Unifications: 50
 Conjuncts:    66
 Disjuncts:    46
+Builtins:     8
 -- out/eval --
 (struct){
   a: (string){ "est" }

--- a/cue/testdata/eval/issue545.txtar
+++ b/cue/testdata/eval/issue545.txtar
@@ -45,6 +45,7 @@ Retain: 0
 Unifications: 65
 Conjuncts:    205
 Disjuncts:    121
+Builtins:     0
 -- out/eval --
 (struct){
   t1: (struct){

--- a/cue/testdata/eval/issue599.txtar
+++ b/cue/testdata/eval/issue599.txtar
@@ -69,6 +69,7 @@ Retain: 0
 Unifications: 47
 Conjuncts:    122
 Disjuncts:    47
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/eval/let.txtar
+++ b/cue/testdata/eval/let.txtar
@@ -168,6 +168,7 @@ Retain: 188
 Unifications: 196
 Conjuncts:    373
 Disjuncts:    248
+Builtins:     2
 -- out/eval --
 Errors:
 indirectReference.y: conflicting values 2 and 1:

--- a/cue/testdata/eval/let_funcs.txtar
+++ b/cue/testdata/eval/let_funcs.txtar
@@ -1,0 +1,117 @@
+-- in.cue --
+import "strings"
+
+#Foo: {
+	#a: string
+	#b: string
+	foo: strings.HasPrefix("\(#a)", #b)
+}
+
+foo: {
+	let env_context = #Foo & {
+		#a: "hello"
+		#b: "world"
+	}
+
+	e1: env_context
+	e2: env_context
+	e3: env_context
+	e4: env_context
+	e5: env_context
+	e6: env_context
+	e7: env_context
+	e8: env_context
+}
+-- out/compile --
+--- in.cue
+{
+  #Foo: {
+    #a: string
+    #b: string
+    foo: 〈import;strings〉.HasPrefix("\(〈0;#a〉)", 〈0;#b〉)
+  }
+  foo: {
+    let env_context#1 = (〈1;#Foo〉 & {
+      #a: "hello"
+      #b: "world"
+    })
+    e1: 〈0;let env_context#1〉
+    e2: 〈0;let env_context#1〉
+    e3: 〈0;let env_context#1〉
+    e4: 〈0;let env_context#1〉
+    e5: 〈0;let env_context#1〉
+    e6: 〈0;let env_context#1〉
+    e7: 〈0;let env_context#1〉
+    e8: 〈0;let env_context#1〉
+  }
+}
+-- out/eval/stats --
+Leaks:  0
+Freed:  42
+Reused: 38
+Allocs: 4
+Retain: 0
+
+Unifications: 42
+Conjuncts:    90
+Disjuncts:    42
+Builtins:     9
+-- out/eval --
+(struct){
+  #Foo: (#struct){
+    #a: (string){ string }
+    #b: (string){ string }
+    foo: (_|_){
+      // [incomplete] #Foo.foo: invalid interpolation: non-concrete value string (type string):
+      //     ./in.cue:6:25
+      //     ./in.cue:4:6
+    }
+  }
+  foo: (struct){
+    let env_context#1 = (#struct){
+      #a: (string){ "hello" }
+      #b: (string){ "world" }
+      foo: (bool){ false }
+    }
+    e1: (#struct){
+      #a: (string){ "hello" }
+      #b: (string){ "world" }
+      foo: (bool){ false }
+    }
+    e2: (#struct){
+      #a: (string){ "hello" }
+      #b: (string){ "world" }
+      foo: (bool){ false }
+    }
+    e3: (#struct){
+      #a: (string){ "hello" }
+      #b: (string){ "world" }
+      foo: (bool){ false }
+    }
+    e4: (#struct){
+      #a: (string){ "hello" }
+      #b: (string){ "world" }
+      foo: (bool){ false }
+    }
+    e5: (#struct){
+      #a: (string){ "hello" }
+      #b: (string){ "world" }
+      foo: (bool){ false }
+    }
+    e6: (#struct){
+      #a: (string){ "hello" }
+      #b: (string){ "world" }
+      foo: (bool){ false }
+    }
+    e7: (#struct){
+      #a: (string){ "hello" }
+      #b: (string){ "world" }
+      foo: (bool){ false }
+    }
+    e8: (#struct){
+      #a: (string){ "hello" }
+      #b: (string){ "world" }
+      foo: (bool){ false }
+    }
+  }
+}

--- a/cue/testdata/eval/let_funcs.txtar
+++ b/cue/testdata/eval/let_funcs.txtar
@@ -53,9 +53,9 @@ Allocs: 4
 Retain: 0
 
 Unifications: 42
-Conjuncts:    90
+Conjuncts:    58
 Disjuncts:    42
-Builtins:     9
+Builtins:     1
 -- out/eval --
 (struct){
   #Foo: (#struct){

--- a/cue/testdata/eval/letjoin.txtar
+++ b/cue/testdata/eval/letjoin.txtar
@@ -53,6 +53,7 @@ Retain: 8
 Unifications: 73
 Conjuncts:    123
 Disjuncts:    69
+Builtins:     0
 -- out/eval --
 (struct){
   t1: (struct){

--- a/cue/testdata/eval/lists.txtar
+++ b/cue/testdata/eval/lists.txtar
@@ -17,6 +17,7 @@ Retain: 6
 Unifications: 15
 Conjuncts:    29
 Disjuncts:    13
+Builtins:     0
 -- out/eval --
 (struct){
   a: (#list){

--- a/cue/testdata/eval/merge.txtar
+++ b/cue/testdata/eval/merge.txtar
@@ -29,6 +29,7 @@ Retain: 0
 Unifications: 22
 Conjuncts:    38
 Disjuncts:    22
+Builtins:     0
 -- out/eval --
 (struct){
   key: (string){ "app01" }

--- a/cue/testdata/eval/required.txtar
+++ b/cue/testdata/eval/required.txtar
@@ -110,6 +110,7 @@ Retain: 1
 Unifications: 27
 Conjuncts:    40
 Disjuncts:    28
+Builtins:     0
 -- out/eval --
 (_|_){
   // [eval]

--- a/cue/testdata/eval/resolve_basic.txtar
+++ b/cue/testdata/eval/resolve_basic.txtar
@@ -18,6 +18,7 @@ Retain: 0
 Unifications: 9
 Conjuncts:    16
 Disjuncts:    9
+Builtins:     0
 -- out/eval --
 (struct){
   a: (int){ 1 }

--- a/cue/testdata/eval/resolve_env.txtar
+++ b/cue/testdata/eval/resolve_env.txtar
@@ -22,6 +22,7 @@ Retain: 0
 Unifications: 15
 Conjuncts:    22
 Disjuncts:    15
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/eval/selectors.txtar
+++ b/cue/testdata/eval/selectors.txtar
@@ -26,6 +26,7 @@ Retain: 0
 Unifications: 18
 Conjuncts:    27
 Disjuncts:    18
+Builtins:     0
 -- out/eval --
 (struct){
   a: (int){ 1 }

--- a/cue/testdata/eval/structs.txtar
+++ b/cue/testdata/eval/structs.txtar
@@ -12,6 +12,7 @@ Retain: 2
 Unifications: 4
 Conjuncts:    7
 Disjuncts:    4
+Builtins:     0
 -- out/eval --
 (struct){
   v: (struct){

--- a/cue/testdata/eval/unify.txtar
+++ b/cue/testdata/eval/unify.txtar
@@ -22,6 +22,7 @@ Retain: 1
 Unifications: 8
 Conjuncts:    19
 Disjuncts:    9
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/export/000.txtar
+++ b/cue/testdata/export/000.txtar
@@ -27,5 +27,6 @@ Retain: 0
 Unifications: 1
 Conjuncts:    2
 Disjuncts:    1
+Builtins:     0
 -- out/eval --
 (string){ "hello" }

--- a/cue/testdata/export/001.txtar
+++ b/cue/testdata/export/001.txtar
@@ -27,5 +27,6 @@ Retain: 0
 Unifications: 1
 Conjuncts:    2
 Disjuncts:    1
+Builtins:     0
 -- out/eval --
 (bytes){ 'hello' }

--- a/cue/testdata/export/002.txtar
+++ b/cue/testdata/export/002.txtar
@@ -38,5 +38,6 @@ Retain: 0
 Unifications: 1
 Conjuncts:    2
 Disjuncts:    1
+Builtins:     0
 -- out/eval --
 (bytes){ 'hello\nworld' }

--- a/cue/testdata/export/003.txtar
+++ b/cue/testdata/export/003.txtar
@@ -38,5 +38,6 @@ Retain: 0
 Unifications: 1
 Conjuncts:    2
 Disjuncts:    1
+Builtins:     0
 -- out/eval --
 (string){ "hello\nworld" }

--- a/cue/testdata/export/004.txtar
+++ b/cue/testdata/export/004.txtar
@@ -32,6 +32,7 @@ Retain: 0
 Unifications: 5
 Conjuncts:    6
 Disjuncts:    5
+Builtins:     0
 -- out/eval --
 (struct){
   $type: (int){ 3 }

--- a/cue/testdata/export/005.txtar
+++ b/cue/testdata/export/005.txtar
@@ -31,6 +31,7 @@ Retain: 0
 Unifications: 7
 Conjuncts:    8
 Disjuncts:    7
+Builtins:     0
 -- out/eval --
 (struct){
   a: (int){ 1 }

--- a/cue/testdata/export/006.txtar
+++ b/cue/testdata/export/006.txtar
@@ -35,6 +35,7 @@ Retain: 0
 Unifications: 8
 Conjuncts:    14
 Disjuncts:    8
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/export/007.txtar
+++ b/cue/testdata/export/007.txtar
@@ -39,6 +39,7 @@ Retain: 0
 Unifications: 8
 Conjuncts:    10
 Disjuncts:    8
+Builtins:     0
 -- out/eval --
 Errors:
 c: undefined field: c:

--- a/cue/testdata/export/008.txtar
+++ b/cue/testdata/export/008.txtar
@@ -24,6 +24,7 @@ Retain: 0
 Unifications: 3
 Conjuncts:    5
 Disjuncts:    3
+Builtins:     0
 -- out/eval --
 Errors:
 a.0: conflicting values 4 and 3:

--- a/cue/testdata/export/009.txtar
+++ b/cue/testdata/export/009.txtar
@@ -52,6 +52,7 @@ Retain: 7
 Unifications: 16
 Conjuncts:    37
 Disjuncts:    20
+Builtins:     0
 -- out/eval --
 (struct){
   a: (#list){

--- a/cue/testdata/export/010.txtar
+++ b/cue/testdata/export/010.txtar
@@ -53,6 +53,7 @@ Retain: 7
 Unifications: 16
 Conjuncts:    37
 Disjuncts:    20
+Builtins:     0
 -- out/eval --
 (struct){
   a: (#list){

--- a/cue/testdata/export/011.txtar
+++ b/cue/testdata/export/011.txtar
@@ -43,6 +43,7 @@ Retain: 0
 Unifications: 5
 Conjuncts:    8
 Disjuncts:    5
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/export/012.txtar
+++ b/cue/testdata/export/012.txtar
@@ -24,6 +24,7 @@ Retain: 0
 Unifications: 3
 Conjuncts:    12
 Disjuncts:    7
+Builtins:     0
 -- out/eval --
 (struct){
   a: ((int|string)){ |(*(string){ "foo" }, *(string){ "bar" }, *(string){ string }, (int){ int }) }

--- a/cue/testdata/export/013.txtar
+++ b/cue/testdata/export/013.txtar
@@ -23,6 +23,7 @@ Retain: 0
 Unifications: 2
 Conjuncts:    5
 Disjuncts:    2
+Builtins:     0
 -- out/eval --
 (struct){
   a: (number){ &(>=0, <=10, !=1) }

--- a/cue/testdata/export/014.txtar
+++ b/cue/testdata/export/014.txtar
@@ -24,6 +24,7 @@ Retain: 0
 Unifications: 2
 Conjuncts:    5
 Disjuncts:    2
+Builtins:     0
 -- out/eval --
 (struct){
   a: (number){ &(>=0, <=10, !=1) }

--- a/cue/testdata/export/015.txtar
+++ b/cue/testdata/export/015.txtar
@@ -30,6 +30,7 @@ Retain: 0
 Unifications: 4
 Conjuncts:    19
 Disjuncts:    16
+Builtins:     0
 -- out/eval --
 (struct){
   a: (int){ |((int){ 1 }, (int){ 2 }) }

--- a/cue/testdata/export/016.txtar
+++ b/cue/testdata/export/016.txtar
@@ -61,6 +61,7 @@ Retain: 0
 Unifications: 14
 Conjuncts:    24
 Disjuncts:    14
+Builtins:     0
 -- out/eval --
 (struct){
   u16: (int){ &(>=0, <=65535, int) }

--- a/cue/testdata/export/017.txtar
+++ b/cue/testdata/export/017.txtar
@@ -46,6 +46,7 @@ Retain: 0
 Unifications: 6
 Conjuncts:    9
 Disjuncts:    6
+Builtins:     0
 -- out/eval --
 (struct){
   a: (#list){

--- a/cue/testdata/export/018.txtar
+++ b/cue/testdata/export/018.txtar
@@ -43,6 +43,7 @@ Retain: 0
 Unifications: 7
 Conjuncts:    12
 Disjuncts:    7
+Builtins:     0
 -- out/eval --
 (struct){
   a: (#list){

--- a/cue/testdata/export/019.txtar
+++ b/cue/testdata/export/019.txtar
@@ -24,6 +24,7 @@ Retain: 0
 Unifications: 3
 Conjuncts:    9
 Disjuncts:    3
+Builtins:     0
 -- out/eval --
 (struct){
   a: (number){ &(>=0, <=10) }

--- a/cue/testdata/export/020.txtar
+++ b/cue/testdata/export/020.txtar
@@ -24,6 +24,7 @@ Retain: 0
 Unifications: 3
 Conjuncts:    4
 Disjuncts:    3
+Builtins:     1
 -- out/eval --
 (struct){
   a: (string){ "" }

--- a/cue/testdata/export/021.txtar
+++ b/cue/testdata/export/021.txtar
@@ -52,6 +52,7 @@ Retain: 10
 Unifications: 8
 Conjuncts:    14
 Disjuncts:    18
+Builtins:     0
 -- out/eval --
 (struct){
   b: (struct){

--- a/cue/testdata/export/022.txtar
+++ b/cue/testdata/export/022.txtar
@@ -93,6 +93,7 @@ Retain: 0
 Unifications: 10
 Conjuncts:    22
 Disjuncts:    14
+Builtins:     0
 -- out/eval --
 (struct){
   job: (struct){

--- a/cue/testdata/export/023.txtar
+++ b/cue/testdata/export/023.txtar
@@ -89,6 +89,7 @@ Retain: 0
 Unifications: 15
 Conjuncts:    26
 Disjuncts:    15
+Builtins:     0
 -- out/eval --
 (struct){
   #emb: (#struct){

--- a/cue/testdata/export/024.txtar
+++ b/cue/testdata/export/024.txtar
@@ -68,6 +68,7 @@ Retain: 0
 Unifications: 23
 Conjuncts:    28
 Disjuncts:    23
+Builtins:     0
 -- out/eval --
 (struct){
   reg: (struct){

--- a/cue/testdata/export/025.txtar
+++ b/cue/testdata/export/025.txtar
@@ -50,6 +50,7 @@ Retain: 10
 Unifications: 9
 Conjuncts:    16
 Disjuncts:    16
+Builtins:     0
 -- out/eval --
 (struct){
   b: (_|_){

--- a/cue/testdata/export/026.txtar
+++ b/cue/testdata/export/026.txtar
@@ -38,6 +38,7 @@ Retain: 0
 Unifications: 1
 Conjuncts:    2
 Disjuncts:    1
+Builtins:     0
 -- out/eval --
 (struct){
 }

--- a/cue/testdata/export/027.txtar
+++ b/cue/testdata/export/027.txtar
@@ -41,6 +41,7 @@ Retain: 0
 Unifications: 3
 Conjuncts:    6
 Disjuncts:    5
+Builtins:     0
 -- out/eval --
 (struct){
   #Foo: (#struct){

--- a/cue/testdata/export/028.txtar
+++ b/cue/testdata/export/028.txtar
@@ -48,6 +48,7 @@ Retain: 0
 Unifications: 6
 Conjuncts:    9
 Disjuncts:    8
+Builtins:     0
 -- out/eval --
 (struct){
   #FindInMap: (#struct){

--- a/cue/testdata/export/029.txtar
+++ b/cue/testdata/export/029.txtar
@@ -59,6 +59,7 @@ Retain: 0
 Unifications: 10
 Conjuncts:    19
 Disjuncts:    12
+Builtins:     0
 -- out/eval --
 (struct){
   #And: (#struct){

--- a/cue/testdata/export/030.txtar
+++ b/cue/testdata/export/030.txtar
@@ -63,6 +63,7 @@ Retain: 1
 Unifications: 28
 Conjuncts:    131
 Disjuncts:    71
+Builtins:     0
 -- out/eval --
 (struct){
   #Foo: (#struct){

--- a/cue/testdata/export/031.txtar
+++ b/cue/testdata/export/031.txtar
@@ -34,6 +34,7 @@ Retain: 0
 Unifications: 6
 Conjuncts:    13
 Disjuncts:    8
+Builtins:     0
 -- out/eval --
 (struct){
   A: (#list){

--- a/cue/testdata/export/032.txtar
+++ b/cue/testdata/export/032.txtar
@@ -32,6 +32,7 @@ Retain: 0
 Unifications: 2
 Conjuncts:    4
 Disjuncts:    2
+Builtins:     0
 -- out/eval --
 (struct){
   foo: (int){ 3 }

--- a/cue/testdata/export/issue2119.txtar
+++ b/cue/testdata/export/issue2119.txtar
@@ -42,6 +42,7 @@ Retain: 4
 Unifications: 24
 Conjuncts:    42
 Disjuncts:    24
+Builtins:     5
 -- out/eval --
 (struct){
   simplified: (struct){

--- a/cue/testdata/export/issue2244.txtar
+++ b/cue/testdata/export/issue2244.txtar
@@ -41,6 +41,7 @@ Retain: 30
 Unifications: 24
 Conjuncts:    58
 Disjuncts:    40
+Builtins:     16
 -- out/eval --
 (struct){
   _#matchPattern(:x): (_|_){

--- a/cue/testdata/export/issue854.txtar
+++ b/cue/testdata/export/issue854.txtar
@@ -33,6 +33,7 @@ Retain: 24
 Unifications: 6
 Conjuncts:    27
 Disjuncts:    11
+Builtins:     0
 -- out/eval --
 (struct){
   theb: (_|_){

--- a/cue/testdata/fulleval/000_detect_conflicting_value.txtar
+++ b/cue/testdata/fulleval/000_detect_conflicting_value.txtar
@@ -23,6 +23,7 @@ Retain: 0
 Unifications: 2
 Conjuncts:    5
 Disjuncts:    4
+Builtins:     0
 -- out/eval --
 Errors:
 a: 2 errors in empty disjunction:

--- a/cue/testdata/fulleval/001_conflicts_in_optional_fields_are_okay_.txtar
+++ b/cue/testdata/fulleval/001_conflicts_in_optional_fields_are_okay_.txtar
@@ -44,6 +44,7 @@ Retain: 0
 Unifications: 10
 Conjuncts:    17
 Disjuncts:    14
+Builtins:     0
 -- out/eval --
 (struct){
   d: (struct){ |((struct){

--- a/cue/testdata/fulleval/002_resolve_all_disjunctions.txtar
+++ b/cue/testdata/fulleval/002_resolve_all_disjunctions.txtar
@@ -91,6 +91,7 @@ Retain: 0
 Unifications: 11
 Conjuncts:    31
 Disjuncts:    23
+Builtins:     0
 -- out/eval --
 (struct){
   service: (struct){

--- a/cue/testdata/fulleval/003_field_templates.txtar
+++ b/cue/testdata/fulleval/003_field_templates.txtar
@@ -139,6 +139,7 @@ Retain: 0
 Unifications: 17
 Conjuncts:    33
 Disjuncts:    21
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/fulleval/004_field_comprehension.txtar
+++ b/cue/testdata/fulleval/004_field_comprehension.txtar
@@ -99,6 +99,7 @@ Retain: 12
 Unifications: 12
 Conjuncts:    17
 Disjuncts:    16
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/fulleval/005_conditional_field.txtar
+++ b/cue/testdata/fulleval/005_conditional_field.txtar
@@ -64,6 +64,7 @@ Retain: 1
 Unifications: 7
 Conjuncts:    7
 Disjuncts:    7
+Builtins:     0
 -- out/eval --
 (struct){
   a: (string){ "foo" }

--- a/cue/testdata/fulleval/006_referencing_field_in_field_comprehension.txtar
+++ b/cue/testdata/fulleval/006_referencing_field_in_field_comprehension.txtar
@@ -66,6 +66,7 @@ Retain: 1
 Unifications: 7
 Conjuncts:    13
 Disjuncts:    8
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/fulleval/007_different_labels_for_templates.txtar
+++ b/cue/testdata/fulleval/007_different_labels_for_templates.txtar
@@ -56,6 +56,7 @@ Retain: 0
 Unifications: 4
 Conjuncts:    9
 Disjuncts:    4
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/fulleval/008_nested_templates_in_one_field.txtar
+++ b/cue/testdata/fulleval/008_nested_templates_in_one_field.txtar
@@ -151,6 +151,7 @@ Retain: 0
 Unifications: 18
 Conjuncts:    30
 Disjuncts:    18
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/fulleval/009_template_unification_within_one_struct.txtar
+++ b/cue/testdata/fulleval/009_template_unification_within_one_struct.txtar
@@ -100,6 +100,7 @@ Retain: 0
 Unifications: 12
 Conjuncts:    23
 Disjuncts:    12
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/fulleval/010_field_comprehensions_with_multiple_keys.txtar
+++ b/cue/testdata/fulleval/010_field_comprehensions_with_multiple_keys.txtar
@@ -178,6 +178,7 @@ Retain: 56
 Unifications: 49
 Conjuncts:    48
 Disjuncts:    61
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/fulleval/011_field_comprehensions_with_templates.txtar
+++ b/cue/testdata/fulleval/011_field_comprehensions_with_templates.txtar
@@ -87,6 +87,7 @@ Retain: 0
 Unifications: 8
 Conjuncts:    12
 Disjuncts:    8
+Builtins:     0
 -- out/eval --
 (struct){
   num: (int){ 1 }

--- a/cue/testdata/fulleval/012_disjunctions_of_lists.txtar
+++ b/cue/testdata/fulleval/012_disjunctions_of_lists.txtar
@@ -42,6 +42,7 @@ Retain: 0
 Unifications: 14
 Conjuncts:    24
 Disjuncts:    18
+Builtins:     0
 -- out/eval --
 (struct){
   l: (list){ |(*(#list){

--- a/cue/testdata/fulleval/013_normalization.txtar
+++ b/cue/testdata/fulleval/013_normalization.txtar
@@ -31,6 +31,7 @@ Retain: 0
 Unifications: 4
 Conjuncts:    10
 Disjuncts:    10
+Builtins:     0
 -- out/eval --
 (struct){
   a: (string){ string }

--- a/cue/testdata/fulleval/014_default_disambiguation_and_elimination.txtar
+++ b/cue/testdata/fulleval/014_default_disambiguation_and_elimination.txtar
@@ -36,6 +36,7 @@ Retain: 0
 Unifications: 6
 Conjuncts:    30
 Disjuncts:    24
+Builtins:     0
 -- out/eval --
 (struct){
   a: (int){ |(*(int){ 1 }, (int){ int }) }

--- a/cue/testdata/fulleval/016_struct_comprehension_with_template.txtar
+++ b/cue/testdata/fulleval/016_struct_comprehension_with_template.txtar
@@ -145,6 +145,7 @@ Retain: 4
 Unifications: 27
 Conjuncts:    70
 Disjuncts:    55
+Builtins:     0
 -- out/eval --
 (struct){
   result: (#list){

--- a/cue/testdata/fulleval/017_resolutions_in_struct_comprehension_keys.txtar
+++ b/cue/testdata/fulleval/017_resolutions_in_struct_comprehension_keys.txtar
@@ -40,6 +40,7 @@ Retain: 3
 Unifications: 5
 Conjuncts:    5
 Disjuncts:    4
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/fulleval/018_recursive_evaluation_within_list.txtar
+++ b/cue/testdata/fulleval/018_recursive_evaluation_within_list.txtar
@@ -68,6 +68,7 @@ Retain: 14
 Unifications: 21
 Conjuncts:    40
 Disjuncts:    31
+Builtins:     0
 -- out/eval --
 (struct){
   l: (#list){

--- a/cue/testdata/fulleval/020_complex_interaction_of_groundness.txtar
+++ b/cue/testdata/fulleval/020_complex_interaction_of_groundness.txtar
@@ -69,6 +69,7 @@ Retain: 5
 Unifications: 10
 Conjuncts:    33
 Disjuncts:    15
+Builtins:     0
 -- out/eval --
 (struct){
   res: (#list){

--- a/cue/testdata/fulleval/021_complex_groundness_2.txtar
+++ b/cue/testdata/fulleval/021_complex_groundness_2.txtar
@@ -79,6 +79,7 @@ Retain: 6
 Unifications: 16
 Conjuncts:    63
 Disjuncts:    22
+Builtins:     0
 -- out/eval --
 (struct){
   r1: (struct){

--- a/cue/testdata/fulleval/022_references_from_template_to_concrete.txtar
+++ b/cue/testdata/fulleval/022_references_from_template_to_concrete.txtar
@@ -95,6 +95,7 @@ Retain: 3
 Unifications: 14
 Conjuncts:    21
 Disjuncts:    15
+Builtins:     0
 -- out/eval --
 (struct){
   res: (#list){

--- a/cue/testdata/fulleval/024_Issue_#23.txtar
+++ b/cue/testdata/fulleval/024_Issue_#23.txtar
@@ -36,6 +36,7 @@ Retain: 0
 Unifications: 7
 Conjuncts:    15
 Disjuncts:    11
+Builtins:     0
 -- out/eval --
 Errors:
 y: 2 errors in empty disjunction:

--- a/cue/testdata/fulleval/026_dont_convert_incomplete_errors_to_non-incomplete.txtar
+++ b/cue/testdata/fulleval/026_dont_convert_incomplete_errors_to_non-incomplete.txtar
@@ -54,6 +54,7 @@ Retain: 75
 Unifications: 17
 Conjuncts:    71
 Disjuncts:    82
+Builtins:     5
 -- out/eval --
 (struct){
   n1: (struct){

--- a/cue/testdata/fulleval/027_len_of_incomplete_types.txtar
+++ b/cue/testdata/fulleval/027_len_of_incomplete_types.txtar
@@ -42,6 +42,7 @@ Retain: 3
 Unifications: 59
 Conjuncts:    105
 Disjuncts:    93
+Builtins:     7
 -- out/eval --
 (struct){
   args: (list){ |(*(#list){

--- a/cue/testdata/fulleval/028_slice_rewrite_bug.txtar
+++ b/cue/testdata/fulleval/028_slice_rewrite_bug.txtar
@@ -65,6 +65,7 @@ Retain: 0
 Unifications: 9
 Conjuncts:    17
 Disjuncts:    9
+Builtins:     0
 -- out/eval --
 (struct){
   fn: (struct){

--- a/cue/testdata/fulleval/029_Issue_#94.txtar
+++ b/cue/testdata/fulleval/029_Issue_#94.txtar
@@ -93,6 +93,7 @@ Retain: 0
 Unifications: 22
 Conjuncts:    32
 Disjuncts:    22
+Builtins:     0
 -- out/eval --
 (struct){
   foo: (struct){

--- a/cue/testdata/fulleval/030_retain_references_with_interleaved_embedding.txtar
+++ b/cue/testdata/fulleval/030_retain_references_with_interleaved_embedding.txtar
@@ -85,6 +85,7 @@ Retain: 1
 Unifications: 8
 Conjuncts:    19
 Disjuncts:    9
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/fulleval/031_comparison_against_bottom.txtar
+++ b/cue/testdata/fulleval/031_comparison_against_bottom.txtar
@@ -69,6 +69,7 @@ Retain: 4
 Unifications: 21
 Conjuncts:    28
 Disjuncts:    21
+Builtins:     0
 -- out/eval --
 Errors:
 err: conflicting values 2 and 1:

--- a/cue/testdata/fulleval/032_or_builtin_should_not_fail_on_non-concrete_empty_list.txtar
+++ b/cue/testdata/fulleval/032_or_builtin_should_not_fail_on_non-concrete_empty_list.txtar
@@ -51,6 +51,7 @@ Retain: 6
 Unifications: 15
 Conjuncts:    32
 Disjuncts:    17
+Builtins:     6
 -- out/eval --
 (struct){
   #Workflow: (#struct){

--- a/cue/testdata/fulleval/034_label_and_field_aliases.txtar
+++ b/cue/testdata/fulleval/034_label_and_field_aliases.txtar
@@ -69,6 +69,7 @@ Retain: 3
 Unifications: 8
 Conjuncts:    10
 Disjuncts:    9
+Builtins:     0
 -- out/eval --
 (struct){
   p: (struct){

--- a/cue/testdata/fulleval/035_optionals_with_label_filters.txtar
+++ b/cue/testdata/fulleval/035_optionals_with_label_filters.txtar
@@ -110,6 +110,7 @@ Retain: 0
 Unifications: 19
 Conjuncts:    45
 Disjuncts:    19
+Builtins:     0
 -- out/eval --
 Errors:
 jobs1.foo1: field not allowed:

--- a/cue/testdata/fulleval/040.txtar
+++ b/cue/testdata/fulleval/040.txtar
@@ -75,6 +75,7 @@ Retain: 0
 Unifications: 15
 Conjuncts:    35
 Disjuncts:    27
+Builtins:     0
 -- out/eval --
 (struct){
   #Task: (#struct){ |((#struct){

--- a/cue/testdata/fulleval/041.txtar
+++ b/cue/testdata/fulleval/041.txtar
@@ -44,6 +44,7 @@ Retain: 0
 Unifications: 7
 Conjuncts:    13
 Disjuncts:    11
+Builtins:     0
 -- out/eval --
 (struct){
   t: (struct){

--- a/cue/testdata/fulleval/042_cross-dependent_comprehension.txtar
+++ b/cue/testdata/fulleval/042_cross-dependent_comprehension.txtar
@@ -48,6 +48,7 @@ Retain: 4
 Unifications: 10
 Conjuncts:    18
 Disjuncts:    12
+Builtins:     0
 -- out/eval --
 (struct){
   #a: (_|_){

--- a/cue/testdata/fulleval/043_optional_expanded_before_lookup.txtar
+++ b/cue/testdata/fulleval/043_optional_expanded_before_lookup.txtar
@@ -78,6 +78,7 @@ Retain: 0
 Unifications: 10
 Conjuncts:    15
 Disjuncts:    10
+Builtins:     0
 -- out/eval --
 (struct){
   test: (struct){

--- a/cue/testdata/fulleval/044_Issue_#178.txtar
+++ b/cue/testdata/fulleval/044_Issue_#178.txtar
@@ -34,6 +34,7 @@ Retain: 5
 Unifications: 5
 Conjuncts:    13
 Disjuncts:    10
+Builtins:     10
 -- out/eval --
 (struct){
   foo: (_|_){

--- a/cue/testdata/fulleval/046_non-structural_direct_cycles.txtar
+++ b/cue/testdata/fulleval/046_non-structural_direct_cycles.txtar
@@ -36,6 +36,7 @@ Retain: 2
 Unifications: 7
 Conjuncts:    10
 Disjuncts:    8
+Builtins:     0
 -- out/eval --
 Errors:
 c2: conflicting values 1 and {bar:1} (mismatched types int and struct):

--- a/cue/testdata/fulleval/047_dont_bind_to_string_labels.txtar
+++ b/cue/testdata/fulleval/047_dont_bind_to_string_labels.txtar
@@ -48,6 +48,7 @@ Retain: 0
 Unifications: 5
 Conjuncts:    6
 Disjuncts:    5
+Builtins:     0
 -- out/eval --
 (struct){
   x: (int){ 1 }

--- a/cue/testdata/fulleval/048_dont_pass_incomplete_values_to_builtins.txtar
+++ b/cue/testdata/fulleval/048_dont_pass_incomplete_values_to_builtins.txtar
@@ -24,6 +24,7 @@ Retain: 0
 Unifications: 3
 Conjuncts:    7
 Disjuncts:    3
+Builtins:     5
 -- out/eval --
 (struct){
   input: (string){ string }

--- a/cue/testdata/fulleval/049_alias_reuse_in_nested_scope.txtar
+++ b/cue/testdata/fulleval/049_alias_reuse_in_nested_scope.txtar
@@ -74,6 +74,7 @@ Retain: 10
 Unifications: 29
 Conjuncts:    40
 Disjuncts:    29
+Builtins:     5
 -- out/eval --
 (struct){
   #Foo: (#struct){

--- a/cue/testdata/fulleval/050_json_Marshaling_detects_incomplete.txtar
+++ b/cue/testdata/fulleval/050_json_Marshaling_detects_incomplete.txtar
@@ -32,6 +32,7 @@ Retain: 5
 Unifications: 16
 Conjuncts:    24
 Disjuncts:    21
+Builtins:     10
 -- out/eval --
 (struct){
   a: (_|_){

--- a/cue/testdata/fulleval/051_detectIncompleteYAML.txtar
+++ b/cue/testdata/fulleval/051_detectIncompleteYAML.txtar
@@ -76,6 +76,7 @@ Retain: 0
 Unifications: 17
 Conjuncts:    32
 Disjuncts:    17
+Builtins:     12
 -- out/eval --
 (struct){
   #Spec: (#struct){

--- a/cue/testdata/fulleval/052_detectIncompleteJSON.txtar
+++ b/cue/testdata/fulleval/052_detectIncompleteJSON.txtar
@@ -68,6 +68,7 @@ Retain: 0
 Unifications: 17
 Conjuncts:    32
 Disjuncts:    17
+Builtins:     12
 -- out/eval --
 (struct){
   #Spec: (#struct){

--- a/cue/testdata/fulleval/053_issue312.txtar
+++ b/cue/testdata/fulleval/053_issue312.txtar
@@ -30,6 +30,7 @@ Retain: 2
 Unifications: 3
 Conjuncts:    8
 Disjuncts:    5
+Builtins:     1
 -- out/eval --
 (struct){ |(*(#struct){
   }, (struct){

--- a/cue/testdata/fulleval/054_issue312.txtar
+++ b/cue/testdata/fulleval/054_issue312.txtar
@@ -40,6 +40,7 @@ Retain: 1
 Unifications: 5
 Conjuncts:    12
 Disjuncts:    9
+Builtins:     0
 -- out/eval --
 (struct){
   y: ((int|struct)){ |(*(int){ 1 }, (struct){

--- a/cue/testdata/fulleval/055_issue318.txtar
+++ b/cue/testdata/fulleval/055_issue318.txtar
@@ -51,6 +51,7 @@ Retain: 0
 Unifications: 8
 Conjuncts:    9
 Disjuncts:    8
+Builtins:     0
 -- out/eval --
 Errors:
 #T.out1: invalid interpolation: undefined field: y:

--- a/cue/testdata/interpolation/041_interpolation.txtar
+++ b/cue/testdata/interpolation/041_interpolation.txtar
@@ -41,6 +41,7 @@ Retain: 12
 Unifications: 9
 Conjuncts:    16
 Disjuncts:    19
+Builtins:     0
 -- out/eval --
 Errors:
 e: invalid interpolation: cannot use [] (type list) as type (bool|string|bytes|number):

--- a/cue/testdata/interpolation/042_multiline_interpolation.txtar
+++ b/cue/testdata/interpolation/042_multiline_interpolation.txtar
@@ -201,6 +201,7 @@ Retain: 0
 Unifications: 9
 Conjuncts:    9
 Disjuncts:    9
+Builtins:     0
 -- out/eval --
 (struct){
   a1: (string){ "before\n4\nafter" }

--- a/cue/testdata/interpolation/incomplete.txtar
+++ b/cue/testdata/interpolation/incomplete.txtar
@@ -25,6 +25,7 @@ Retain: 0
 Unifications: 7
 Conjuncts:    11
 Disjuncts:    7
+Builtins:     0
 -- out/eval --
 (struct){
   a: (string){ "foo" }

--- a/cue/testdata/interpolation/issue487.txtar
+++ b/cue/testdata/interpolation/issue487.txtar
@@ -23,6 +23,7 @@ Retain: 0
 Unifications: 15
 Conjuncts:    29
 Disjuncts:    15
+Builtins:     0
 -- out/eval --
 (struct){
   t1: (struct){

--- a/cue/testdata/interpolation/scalars.txtar
+++ b/cue/testdata/interpolation/scalars.txtar
@@ -28,6 +28,7 @@ Retain: 0
 Unifications: 11
 Conjuncts:    12
 Disjuncts:    11
+Builtins:     0
 -- out/eval --
 (struct){
   bool1: (string){ "1+1=2:  true" }

--- a/cue/testdata/lists/019_list_types.txtar
+++ b/cue/testdata/lists/019_list_types.txtar
@@ -126,6 +126,7 @@ Retain: 20
 Unifications: 41
 Conjuncts:    75
 Disjuncts:    45
+Builtins:     0
 -- out/eval --
 Errors:
 e0: incompatible list lengths (1 and 2)

--- a/cue/testdata/lists/020_list_arithmetic.txtar
+++ b/cue/testdata/lists/020_list_arithmetic.txtar
@@ -334,6 +334,7 @@ Retain: 210
 Unifications: 331
 Conjuncts:    475
 Disjuncts:    253
+Builtins:     0
 -- out/eval --
 (struct){
   l0: (#list){

--- a/cue/testdata/lists/021_list_equality.txtar
+++ b/cue/testdata/lists/021_list_equality.txtar
@@ -492,6 +492,7 @@ Retain: 96
 Unifications: 234
 Conjuncts:    234
 Disjuncts:    330
+Builtins:     0
 -- out/eval --
 (struct){
   eq0: (bool){ true }

--- a/cue/testdata/packages/embed.txtar
+++ b/cue/testdata/packages/embed.txtar
@@ -33,6 +33,7 @@ Retain: 4
 Unifications: 11
 Conjuncts:    25
 Disjuncts:    13
+Builtins:     0
 -- out/eval --
 (struct){
   foo: (struct){

--- a/cue/testdata/packages/issue398.txtar
+++ b/cue/testdata/packages/issue398.txtar
@@ -28,6 +28,7 @@ Retain: 2
 Unifications: 7
 Conjuncts:    13
 Disjuncts:    8
+Builtins:     0
 -- out/eval --
 (struct){
   xx: (int){ 1 }

--- a/cue/testdata/packages/sub.txtar
+++ b/cue/testdata/packages/sub.txtar
@@ -24,6 +24,7 @@ Retain: 3
 Unifications: 4
 Conjuncts:    5
 Disjuncts:    4
+Builtins:     0
 -- out/eval --
 (string){
   "Hello World!"

--- a/cue/testdata/references/embed_self.txtar
+++ b/cue/testdata/references/embed_self.txtar
@@ -13,6 +13,7 @@ Retain: 1
 Unifications: 2
 Conjuncts:    4
 Disjuncts:    3
+Builtins:     0
 -- out/eval --
 (struct){
   Foo: (struct){

--- a/cue/testdata/references/errors.txtar
+++ b/cue/testdata/references/errors.txtar
@@ -40,6 +40,7 @@ Retain: 0
 Unifications: 17
 Conjuncts:    29
 Disjuncts:    17
+Builtins:     0
 -- out/eval --
 Errors:
 missingFieldClosed.r: undefined field: b:

--- a/cue/testdata/references/incomplete.txtar
+++ b/cue/testdata/references/incomplete.txtar
@@ -39,6 +39,7 @@ Retain: 1
 Unifications: 18
 Conjuncts:    26
 Disjuncts:    18
+Builtins:     0
 -- out/eval --
 Errors:
 incompleteIndex.a: invalid index top (invalid type _):

--- a/cue/testdata/references/index.txtar
+++ b/cue/testdata/references/index.txtar
@@ -39,6 +39,7 @@ Retain: 12
 Unifications: 40
 Conjuncts:    50
 Disjuncts:    45
+Builtins:     0
 -- out/eval --
 Errors:
 outOfBoundsDisjunction: invalid list index 1 (out of bounds):

--- a/cue/testdata/references/labels.txtar
+++ b/cue/testdata/references/labels.txtar
@@ -102,6 +102,7 @@ Retain: 3
 Unifications: 56
 Conjuncts:    103
 Disjuncts:    61
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/references/labelstop.txtar
+++ b/cue/testdata/references/labelstop.txtar
@@ -13,6 +13,7 @@ Retain: 0
 Unifications: 3
 Conjuncts:    5
 Disjuncts:    3
+Builtins:     0
 -- out/eval --
 (struct){
   bar: (struct){

--- a/cue/testdata/references/let.txtar
+++ b/cue/testdata/references/let.txtar
@@ -294,6 +294,7 @@ Retain: 10
 Unifications: 115
 Conjuncts:    169
 Disjuncts:    117
+Builtins:     6
 -- out/eval --
 (struct){
   a1list: (#list){

--- a/cue/testdata/references/optional.txtar
+++ b/cue/testdata/references/optional.txtar
@@ -22,6 +22,7 @@ Retain: 0
 Unifications: 4
 Conjuncts:    4
 Disjuncts:    4
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/references/package.txtar
+++ b/cue/testdata/references/package.txtar
@@ -31,6 +31,7 @@ Retain: 2
 Unifications: 5
 Conjuncts:    6
 Disjuncts:    6
+Builtins:     0
 -- out/eval --
 (struct){
   a: (int){ 1 }

--- a/cue/testdata/references/value.txtar
+++ b/cue/testdata/references/value.txtar
@@ -20,6 +20,7 @@ Retain: 0
 Unifications: 13
 Conjuncts:    20
 Disjuncts:    13
+Builtins:     0
 -- out/eval --
 (struct){
   structShorthand: (struct){

--- a/cue/testdata/resolve/000_convert___to_top.txtar
+++ b/cue/testdata/resolve/000_convert___to_top.txtar
@@ -33,6 +33,7 @@ Retain: 0
 Unifications: 2
 Conjuncts:    2
 Disjuncts:    2
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/resolve/001.txtar
+++ b/cue/testdata/resolve/001.txtar
@@ -71,6 +71,7 @@ Retain: 5
 Unifications: 9
 Conjuncts:    9
 Disjuncts:    12
+Builtins:     0
 -- out/eval --
 (struct){
   a: (int){ 3 }

--- a/cue/testdata/resolve/004.txtar
+++ b/cue/testdata/resolve/004.txtar
@@ -48,6 +48,7 @@ Retain: 0
 Unifications: 5
 Conjuncts:    11
 Disjuncts:    5
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/resolve/005_JSON.txtar
+++ b/cue/testdata/resolve/005_JSON.txtar
@@ -54,6 +54,7 @@ Retain: 0
 Unifications: 6
 Conjuncts:    8
 Disjuncts:    6
+Builtins:     0
 -- out/eval --
 (struct){
   a: (int){ 3 }

--- a/cue/testdata/resolve/006_arithmetic.txtar
+++ b/cue/testdata/resolve/006_arithmetic.txtar
@@ -38,6 +38,7 @@ Retain: 0
 Unifications: 7
 Conjuncts:    8
 Disjuncts:    7
+Builtins:     0
 -- out/eval --
 Errors:
 e2: conflicting values int and 2.0 (mismatched types int and float):

--- a/cue/testdata/resolve/007_inequality.txtar
+++ b/cue/testdata/resolve/007_inequality.txtar
@@ -54,6 +54,7 @@ Retain: 2
 Unifications: 9
 Conjuncts:    9
 Disjuncts:    9
+Builtins:     0
 -- out/eval --
 (struct){
   a: (bool){ true }

--- a/cue/testdata/resolve/008_attributes.txtar
+++ b/cue/testdata/resolve/008_attributes.txtar
@@ -43,6 +43,7 @@ Retain: 0
 Unifications: 9
 Conjuncts:    16
 Disjuncts:    9
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/resolve/009_optional_field_unification.txtar
+++ b/cue/testdata/resolve/009_optional_field_unification.txtar
@@ -73,6 +73,7 @@ Retain: 0
 Unifications: 11
 Conjuncts:    19
 Disjuncts:    11
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/resolve/010_optional_field_resolves_to_incomplete.txtar
+++ b/cue/testdata/resolve/010_optional_field_resolves_to_incomplete.txtar
@@ -35,6 +35,7 @@ Retain: 0
 Unifications: 5
 Conjuncts:    5
 Disjuncts:    5
+Builtins:     0
 -- out/eval --
 (struct){
   r: (struct){

--- a/cue/testdata/resolve/011_bounds.txtar
+++ b/cue/testdata/resolve/011_bounds.txtar
@@ -175,6 +175,7 @@ Retain: 0
 Unifications: 50
 Conjuncts:    126
 Disjuncts:    50
+Builtins:     0
 -- out/eval --
 Errors:
 e1: conflicting values null and !=null (mismatched types null and (bool|string|bytes|func|list|struct|number)):

--- a/cue/testdata/resolve/012_bound_conversions.txtar
+++ b/cue/testdata/resolve/012_bound_conversions.txtar
@@ -56,6 +56,7 @@ Retain: 0
 Unifications: 12
 Conjuncts:    35
 Disjuncts:    12
+Builtins:     0
 -- out/eval --
 Errors:
 c4: conflicting values 1.2 and int (mismatched types float and int):

--- a/cue/testdata/resolve/013_custom_validators.txtar
+++ b/cue/testdata/resolve/013_custom_validators.txtar
@@ -29,6 +29,7 @@ Retain: 0
 Unifications: 4
 Conjuncts:    8
 Disjuncts:    4
+Builtins:     0
 -- out/eval --
 Errors:
 b: invalid value "dog" (does not satisfy strings.ContainsAny("c")):

--- a/cue/testdata/resolve/014_null_coalescing.txtar
+++ b/cue/testdata/resolve/014_null_coalescing.txtar
@@ -39,6 +39,7 @@ Retain: 0
 Unifications: 4
 Conjuncts:    8
 Disjuncts:    8
+Builtins:     0
 -- out/eval --
 (struct){
   a: (null){ null }

--- a/cue/testdata/resolve/016_index.txtar
+++ b/cue/testdata/resolve/016_index.txtar
@@ -101,6 +101,7 @@ Retain: 16
 Unifications: 34
 Conjuncts:    48
 Disjuncts:    46
+Builtins:     0
 -- out/eval --
 Errors:
 c: invalid list index "3" (type string):

--- a/cue/testdata/resolve/017_disjunctions_of_lists.txtar
+++ b/cue/testdata/resolve/017_disjunctions_of_lists.txtar
@@ -42,6 +42,7 @@ Retain: 0
 Unifications: 14
 Conjuncts:    24
 Disjuncts:    18
+Builtins:     0
 -- out/eval --
 (struct){
   l: (list){ |((#list){

--- a/cue/testdata/resolve/018_slice.txtar
+++ b/cue/testdata/resolve/018_slice.txtar
@@ -61,6 +61,7 @@ Retain: 8
 Unifications: 18
 Conjuncts:    18
 Disjuncts:    18
+Builtins:     0
 -- out/eval --
 Errors:
 e1: index 1 out of range:

--- a/cue/testdata/resolve/022_list_unification.txtar
+++ b/cue/testdata/resolve/022_list_unification.txtar
@@ -42,6 +42,7 @@ Retain: 2
 Unifications: 11
 Conjuncts:    20
 Disjuncts:    13
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/resolve/023_correct_error_messages.txtar
+++ b/cue/testdata/resolve/023_correct_error_messages.txtar
@@ -23,6 +23,7 @@ Retain: 0
 Unifications: 2
 Conjuncts:    3
 Disjuncts:    2
+Builtins:     0
 -- out/eval --
 Errors:
 a: conflicting values "a" and 1 (mismatched types string and int):

--- a/cue/testdata/resolve/024_structs.txtar
+++ b/cue/testdata/resolve/024_structs.txtar
@@ -50,6 +50,7 @@ Retain: 2
 Unifications: 13
 Conjuncts:    33
 Disjuncts:    15
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/resolve/025_definitions.txtar
+++ b/cue/testdata/resolve/025_definitions.txtar
@@ -127,6 +127,7 @@ Retain: 0
 Unifications: 28
 Conjuncts:    43
 Disjuncts:    28
+Builtins:     0
 -- out/eval --
 Errors:
 foo.feild: field not allowed:

--- a/cue/testdata/resolve/027_new-style_definitions.txtar
+++ b/cue/testdata/resolve/027_new-style_definitions.txtar
@@ -74,6 +74,7 @@ Retain: 0
 Unifications: 11
 Conjuncts:    16
 Disjuncts:    11
+Builtins:     0
 -- out/eval --
 (struct){
   #Foo: (#struct){

--- a/cue/testdata/resolve/029_non-closed_definition_carries_over_closedness_to_enclosed_template.txtar
+++ b/cue/testdata/resolve/029_non-closed_definition_carries_over_closedness_to_enclosed_template.txtar
@@ -112,6 +112,7 @@ Retain: 0
 Unifications: 21
 Conjuncts:    34
 Disjuncts:    23
+Builtins:     0
 -- out/eval --
 Errors:
 a.v.b: field not allowed:

--- a/cue/testdata/resolve/030_definitions_with_disjunctions.txtar
+++ b/cue/testdata/resolve/030_definitions_with_disjunctions.txtar
@@ -69,6 +69,7 @@ Retain: 0
 Unifications: 25
 Conjuncts:    45
 Disjuncts:    33
+Builtins:     0
 -- out/eval --
 Errors:
 bar.c: field not allowed:

--- a/cue/testdata/resolve/031_definitions_with_disjunctions_recurisive.txtar
+++ b/cue/testdata/resolve/031_definitions_with_disjunctions_recurisive.txtar
@@ -59,6 +59,7 @@ Retain: 0
 Unifications: 9
 Conjuncts:    13
 Disjuncts:    11
+Builtins:     0
 -- out/eval --
 (struct){
   #Foo: (#struct){

--- a/cue/testdata/resolve/033_top-level_definition_with_struct_and_disjunction.txtar
+++ b/cue/testdata/resolve/033_top-level_definition_with_struct_and_disjunction.txtar
@@ -60,6 +60,7 @@ Retain: 0
 Unifications: 8
 Conjuncts:    15
 Disjuncts:    10
+Builtins:     0
 -- out/eval --
 (struct){
   #def: (#struct){ |((#struct){

--- a/cue/testdata/resolve/034_closing_structs.txtar
+++ b/cue/testdata/resolve/034_closing_structs.txtar
@@ -61,6 +61,7 @@ Retain: 15
 Unifications: 50
 Conjuncts:    115
 Disjuncts:    50
+Builtins:     15
 -- out/eval --
 (struct){
   op: (struct){

--- a/cue/testdata/resolve/035_excluded_embedding_from_closing.txtar
+++ b/cue/testdata/resolve/035_excluded_embedding_from_closing.txtar
@@ -75,6 +75,7 @@ Retain: 0
 Unifications: 21
 Conjuncts:    29
 Disjuncts:    21
+Builtins:     0
 -- out/eval --
 Errors:
 V.b.extra: field not allowed:

--- a/cue/testdata/resolve/038_incomplete_comprehensions.txtar
+++ b/cue/testdata/resolve/038_incomplete_comprehensions.txtar
@@ -57,6 +57,7 @@ Retain: 9
 Unifications: 11
 Conjuncts:    16
 Disjuncts:    16
+Builtins:     0
 -- out/eval --
 (struct){
   A: (_|_){

--- a/cue/testdata/resolve/039_reference_to_root.txtar
+++ b/cue/testdata/resolve/039_reference_to_root.txtar
@@ -87,6 +87,7 @@ Retain: 0
 Unifications: 21
 Conjuncts:    53
 Disjuncts:    21
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/resolve/040_references_from_template_to_concrete.txtar
+++ b/cue/testdata/resolve/040_references_from_template_to_concrete.txtar
@@ -95,6 +95,7 @@ Retain: 3
 Unifications: 14
 Conjuncts:    21
 Disjuncts:    15
+Builtins:     0
 -- out/eval --
 (struct){
   res: (#list){

--- a/cue/testdata/resolve/043_diamond-shaped_constraints.txtar
+++ b/cue/testdata/resolve/043_diamond-shaped_constraints.txtar
@@ -108,6 +108,7 @@ Retain: 0
 Unifications: 16
 Conjuncts:    25
 Disjuncts:    16
+Builtins:     0
 -- out/eval --
 (struct){
   S: (struct){

--- a/cue/testdata/resolve/044_field_templates.txtar
+++ b/cue/testdata/resolve/044_field_templates.txtar
@@ -139,6 +139,7 @@ Retain: 0
 Unifications: 17
 Conjuncts:    33
 Disjuncts:    21
+Builtins:     0
 -- out/eval --
 (struct){
   a: (struct){

--- a/cue/testdata/resolve/045_range_unification.txtar
+++ b/cue/testdata/resolve/045_range_unification.txtar
@@ -142,6 +142,7 @@ Retain: 0
 Unifications: 36
 Conjuncts:    120
 Disjuncts:    36
+Builtins:     0
 -- out/eval --
 Errors:
 b14: incompatible bounds >=6 and <=5:

--- a/cue/testdata/resolve/046_predefined_ranges.txtar
+++ b/cue/testdata/resolve/046_predefined_ranges.txtar
@@ -37,6 +37,7 @@ Retain: 0
 Unifications: 4
 Conjuncts:    7
 Disjuncts:    4
+Builtins:     0
 -- out/eval --
 Errors:
 e1: invalid value 100000 (out of bound <=32767):

--- a/cue/testdata/resolve/047_struct_comprehensions.txtar
+++ b/cue/testdata/resolve/047_struct_comprehensions.txtar
@@ -87,6 +87,7 @@ Retain: 2
 Unifications: 10
 Conjuncts:    19
 Disjuncts:    13
+Builtins:     0
 -- out/eval --
 (struct){
   obj: (struct){

--- a/cue/testdata/resolve/048_builtins.txtar
+++ b/cue/testdata/resolve/048_builtins.txtar
@@ -89,6 +89,7 @@ Retain: 22
 Unifications: 55
 Conjuncts:    125
 Disjuncts:    75
+Builtins:     19
 -- out/eval --
 Errors:
 o3.a: 2 errors in empty disjunction:

--- a/cue/testdata/scalars/embed.txtar
+++ b/cue/testdata/scalars/embed.txtar
@@ -160,6 +160,7 @@ Retain: 57
 Unifications: 128
 Conjuncts:    297
 Disjuncts:    164
+Builtins:     1
 -- out/eval --
 Errors:
 listEmbed.b6: invalid list index 5 (out of bounds):

--- a/cue/testdata/scalars/emptystruct.txtar
+++ b/cue/testdata/scalars/emptystruct.txtar
@@ -82,6 +82,7 @@ Retain: 0
 Unifications: 48
 Conjuncts:    107
 Disjuncts:    54
+Builtins:     0
 -- out/eval --
 (struct){
   elipsis: (struct){

--- a/cue/testdata/scalars/yield.txtar
+++ b/cue/testdata/scalars/yield.txtar
@@ -30,6 +30,7 @@ Retain: 3
 Unifications: 7
 Conjuncts:    13
 Disjuncts:    7
+Builtins:     0
 -- out/eval --
 Errors:
 ifScalarConflict: conflicting values "soo" and 5 (mismatched types string and int):

--- a/internal/core/adt/eval.go
+++ b/internal/core/adt/eval.go
@@ -1573,6 +1573,15 @@ func (n *nodeContext) evalExpr(v Conjunct, state vertexStatus) {
 		}
 		v.CloseInfo = ci
 
+		if _, ok := x.(*LetReference); ok {
+			if arc.status == finalized {
+				if b, ok := arc.BaseValue.(*Bottom); !ok || !b.IsIncomplete() {
+					n.addExprConjunct(MakeRootConjunct(nil, arc.ToDataAll(n.ctx, ToDataOnlyRegular(false))), arc.status)
+					return
+				}
+			}
+		}
+
 		n.addVertexConjuncts(v, arc, false)
 
 	case Evaluator:

--- a/internal/core/adt/expr.go
+++ b/internal/core/adt/expr.go
@@ -1481,6 +1481,7 @@ func (x *CallExpr) evaluate(c *OpContext, state vertexStatus) Value {
 	if b.IsValidator(len(args)) {
 		return &BuiltinValidator{x, b, args}
 	}
+	c.stats.Builtins++
 	result := b.call(c, pos(x), false, args)
 	if result == nil {
 		return nil

--- a/tools/flow/testdata/concrete.txtar
+++ b/tools/flow/testdata/concrete.txtar
@@ -32,6 +32,17 @@ graph TD
 	text:  "v"
 	value: "v"
 }
+-- out/run/t1/stats --
+Leaks:  0
+Freed:  0
+Reused: 0
+Allocs: 0
+Retain: 0
+
+Unifications: 0
+Conjuncts:    0
+Disjuncts:    0
+Builtins:     0
 -- out/run/t2 --
 graph TD
   t0("root.t1 [Terminated]")
@@ -44,16 +55,6 @@ graph TD
 	text:  "v"
 	value: "v"
 }
--- out/run/t1/stats --
-Leaks:  0
-Freed:  0
-Reused: 0
-Allocs: 0
-Retain: 0
-
-Unifications: 0
-Conjuncts:    0
-Disjuncts:    0
 -- out/run/t2/stats --
 Leaks:  0
 Freed:  0
@@ -64,6 +65,7 @@ Retain: 0
 Unifications: 0
 Conjuncts:    0
 Disjuncts:    0
+Builtins:     0
 -- out/run/stats/totals --
 Leaks:  0
 Freed:  0
@@ -74,3 +76,4 @@ Retain: 0
 Unifications: 0
 Conjuncts:    0
 Disjuncts:    0
+Builtins:     0

--- a/tools/flow/testdata/cycle.txtar
+++ b/tools/flow/testdata/cycle.txtar
@@ -42,3 +42,4 @@ Retain: 0
 Unifications: 0
 Conjuncts:    0
 Disjuncts:    0
+Builtins:     0

--- a/tools/flow/testdata/dep.txtar
+++ b/tools/flow/testdata/dep.txtar
@@ -105,6 +105,17 @@ graph TD
 	b:   3
 	$id: "valToOut"
 }
+-- out/run/t1/stats --
+Leaks:  0
+Freed:  0
+Reused: 0
+Allocs: 0
+Retain: 0
+
+Unifications: 0
+Conjuncts:    0
+Disjuncts:    0
+Builtins:     0
 -- out/run/t2 --
 graph TD
   t0("root.a [Terminated]")
@@ -133,6 +144,17 @@ graph TD
 	$id:   "valToOut"
 	index: int
 }
+-- out/run/t2/stats --
+Leaks:  0
+Freed:  0
+Reused: 0
+Allocs: 0
+Retain: 0
+
+Unifications: 0
+Conjuncts:    0
+Disjuncts:    0
+Builtins:     0
 -- out/run/t3 --
 graph TD
   t0("root.a [Terminated]")
@@ -161,6 +183,17 @@ graph TD
 	//cue:path: root.concreteValueInGeneratedSubfield.index
 	let INDEX = int
 }
+-- out/run/t3/stats --
+Leaks:  0
+Freed:  0
+Reused: 0
+Allocs: 0
+Retain: 0
+
+Unifications: 0
+Conjuncts:    0
+Disjuncts:    0
+Builtins:     0
 -- out/run/t4 --
 graph TD
   t0("root.a [Terminated]")
@@ -193,6 +226,17 @@ graph TD
 	//cue:path: root.concreteValueInGeneratedSubfield.index
 	let INDEX = int
 }
+-- out/run/t4/stats --
+Leaks:  0
+Freed:  0
+Reused: 0
+Allocs: 0
+Retain: 0
+
+Unifications: 0
+Conjuncts:    0
+Disjuncts:    0
+Builtins:     0
 -- out/run/t5 --
 graph TD
   t0("root.a [Terminated]")
@@ -218,6 +262,17 @@ graph TD
 	x:   3
 	$id: "valToOut"
 }
+-- out/run/t5/stats --
+Leaks:  0
+Freed:  0
+Reused: 0
+Allocs: 0
+Retain: 0
+
+Unifications: 0
+Conjuncts:    0
+Disjuncts:    0
+Builtins:     0
 -- out/run/t6 --
 graph TD
   t0("root.a [Terminated]")
@@ -247,6 +302,17 @@ graph TD
 	$id:        "valToOut"
 	incomplete: _
 }
+-- out/run/t6/stats --
+Leaks:  0
+Freed:  0
+Reused: 0
+Allocs: 0
+Retain: 0
+
+Unifications: 0
+Conjuncts:    0
+Disjuncts:    0
+Builtins:     0
 -- out/run/t7 --
 graph TD
   t0("root.a [Terminated]")
@@ -277,6 +343,17 @@ graph TD
 	//cue:path: root.indirectTaskRootReference.incomplete
 	let INCOMPLETE = _
 }
+-- out/run/t7/stats --
+Leaks:  0
+Freed:  0
+Reused: 0
+Allocs: 0
+Retain: 0
+
+Unifications: 0
+Conjuncts:    0
+Disjuncts:    0
+Builtins:     0
 -- out/run/t8 --
 graph TD
   t0("root.a [Terminated]")
@@ -310,6 +387,17 @@ graph TD
 	//cue:path: root.indirectTaskRootReference.incomplete
 	let INCOMPLETE = _
 }
+-- out/run/t8/stats --
+Leaks:  0
+Freed:  0
+Reused: 0
+Allocs: 0
+Retain: 0
+
+Unifications: 0
+Conjuncts:    0
+Disjuncts:    0
+Builtins:     0
 -- out/run/t9 --
 graph TD
   t0("root.a [Terminated]")
@@ -345,86 +433,6 @@ graph TD
 	//cue:path: root.indirectTaskRootReference.incomplete
 	let INCOMPLETE = _
 }
--- out/run/t1/stats --
-Leaks:  0
-Freed:  0
-Reused: 0
-Allocs: 0
-Retain: 0
-
-Unifications: 0
-Conjuncts:    0
-Disjuncts:    0
--- out/run/t2/stats --
-Leaks:  0
-Freed:  0
-Reused: 0
-Allocs: 0
-Retain: 0
-
-Unifications: 0
-Conjuncts:    0
-Disjuncts:    0
--- out/run/t3/stats --
-Leaks:  0
-Freed:  0
-Reused: 0
-Allocs: 0
-Retain: 0
-
-Unifications: 0
-Conjuncts:    0
-Disjuncts:    0
--- out/run/t4/stats --
-Leaks:  0
-Freed:  0
-Reused: 0
-Allocs: 0
-Retain: 0
-
-Unifications: 0
-Conjuncts:    0
-Disjuncts:    0
--- out/run/t5/stats --
-Leaks:  0
-Freed:  0
-Reused: 0
-Allocs: 0
-Retain: 0
-
-Unifications: 0
-Conjuncts:    0
-Disjuncts:    0
--- out/run/t6/stats --
-Leaks:  0
-Freed:  0
-Reused: 0
-Allocs: 0
-Retain: 0
-
-Unifications: 0
-Conjuncts:    0
-Disjuncts:    0
--- out/run/t7/stats --
-Leaks:  0
-Freed:  0
-Reused: 0
-Allocs: 0
-Retain: 0
-
-Unifications: 0
-Conjuncts:    0
-Disjuncts:    0
--- out/run/t8/stats --
-Leaks:  0
-Freed:  0
-Reused: 0
-Allocs: 0
-Retain: 0
-
-Unifications: 0
-Conjuncts:    0
-Disjuncts:    0
 -- out/run/t9/stats --
 Leaks:  0
 Freed:  0
@@ -435,6 +443,7 @@ Retain: 0
 Unifications: 0
 Conjuncts:    0
 Disjuncts:    0
+Builtins:     0
 -- out/run/stats/totals --
 Leaks:  1
 Freed:  0
@@ -445,3 +454,4 @@ Retain: 1
 Unifications: 1
 Conjuncts:    1
 Disjuncts:    1
+Builtins:     0

--- a/tools/flow/testdata/dynamic.txtar
+++ b/tools/flow/testdata/dynamic.txtar
@@ -49,6 +49,17 @@ graph TD
 	$id: "list"
 	out: [1, 2]
 }
+-- out/run/t1/stats --
+Leaks:  0
+Freed:  24
+Reused: 16
+Allocs: 8
+Retain: 0
+
+Unifications: 24
+Conjuncts:    38
+Disjuncts:    24
+Builtins:     0
 -- out/run/t2 --
 graph TD
   t0("root.a [Terminated]")
@@ -65,6 +76,17 @@ graph TD
 	out: "foo2"
 	val: "foo2"
 }
+-- out/run/t2/stats --
+Leaks:  0
+Freed:  23
+Reused: 23
+Allocs: 0
+Retain: 0
+
+Unifications: 23
+Conjuncts:    42
+Disjuncts:    23
+Builtins:     0
 -- out/run/t3 --
 graph TD
   t0("root.a [Terminated]")
@@ -87,6 +109,17 @@ graph TD
 	}]
 	out: [1, 2]
 }
+-- out/run/t3/stats --
+Leaks:  0
+Freed:  31
+Reused: 29
+Allocs: 2
+Retain: 0
+
+Unifications: 31
+Conjuncts:    58
+Disjuncts:    31
+Builtins:     0
 -- out/run/t4 --
 graph TD
   t0("root.a [Terminated]")
@@ -104,36 +137,6 @@ graph TD
 	out: "foo2"
 	val: "foo2"
 }
--- out/run/t1/stats --
-Leaks:  0
-Freed:  24
-Reused: 16
-Allocs: 8
-Retain: 0
-
-Unifications: 24
-Conjuncts:    38
-Disjuncts:    24
--- out/run/t2/stats --
-Leaks:  0
-Freed:  23
-Reused: 23
-Allocs: 0
-Retain: 0
-
-Unifications: 23
-Conjuncts:    42
-Disjuncts:    23
--- out/run/t3/stats --
-Leaks:  0
-Freed:  31
-Reused: 29
-Allocs: 2
-Retain: 0
-
-Unifications: 31
-Conjuncts:    58
-Disjuncts:    31
 -- out/run/t4/stats --
 Leaks:  0
 Freed:  29
@@ -144,6 +147,7 @@ Retain: 0
 Unifications: 29
 Conjuncts:    60
 Disjuncts:    29
+Builtins:     0
 -- out/run/stats/totals --
 Leaks:  0
 Freed:  107
@@ -154,3 +158,4 @@ Retain: 0
 Unifications: 107
 Conjuncts:    198
 Disjuncts:    107
+Builtins:     0

--- a/tools/flow/testdata/failure.txtar
+++ b/tools/flow/testdata/failure.txtar
@@ -30,3 +30,4 @@ Retain: 0
 Unifications: 0
 Conjuncts:    0
 Disjuncts:    0
+Builtins:     0

--- a/tools/flow/testdata/hidden.txtar
+++ b/tools/flow/testdata/hidden.txtar
@@ -51,6 +51,17 @@ graph TD
 	val: "foo"
 	out: "foo"
 }
+-- out/run/t1/stats --
+Leaks:  0
+Freed:  23
+Reused: 18
+Allocs: 5
+Retain: 0
+
+Unifications: 23
+Conjuncts:    42
+Disjuncts:    23
+Builtins:     0
 -- out/run/t2 --
 graph TD
   t0("root.a [Terminated]")
@@ -71,6 +82,17 @@ graph TD
 	val: "bar"
 	out: "bar"
 }
+-- out/run/t2/stats --
+Leaks:  0
+Freed:  23
+Reused: 23
+Allocs: 0
+Retain: 0
+
+Unifications: 23
+Conjuncts:    34
+Disjuncts:    23
+Builtins:     0
 -- out/run/t3 --
 graph TD
   t0("root.a [Terminated]")
@@ -85,26 +107,6 @@ graph TD
 	$id: "valToOut"
 	out: "foobar"
 }
--- out/run/t1/stats --
-Leaks:  0
-Freed:  23
-Reused: 18
-Allocs: 5
-Retain: 0
-
-Unifications: 23
-Conjuncts:    42
-Disjuncts:    23
--- out/run/t2/stats --
-Leaks:  0
-Freed:  23
-Reused: 23
-Allocs: 0
-Retain: 0
-
-Unifications: 23
-Conjuncts:    34
-Disjuncts:    23
 -- out/run/t3/stats --
 Leaks:  0
 Freed:  0
@@ -115,6 +117,7 @@ Retain: 0
 Unifications: 0
 Conjuncts:    0
 Disjuncts:    0
+Builtins:     0
 -- out/run/stats/totals --
 Leaks:  0
 Freed:  46
@@ -125,3 +128,4 @@ Retain: 0
 Unifications: 46
 Conjuncts:    76
 Disjuncts:    46
+Builtins:     0

--- a/tools/flow/testdata/infer.txtar
+++ b/tools/flow/testdata/infer.txtar
@@ -39,6 +39,17 @@ graph TD
 {
 	$id: "valToOut"
 }
+-- out/run/t1/stats --
+Leaks:  0
+Freed:  0
+Reused: 0
+Allocs: 0
+Retain: 0
+
+Unifications: 0
+Conjuncts:    0
+Disjuncts:    0
+Builtins:     0
 -- out/run/t2 --
 graph TD
   t0("root.t1 [Ready]")
@@ -54,6 +65,17 @@ graph TD
 		$id: "valToOut"
 	}
 }
+-- out/run/t2/stats --
+Leaks:  0
+Freed:  0
+Reused: 0
+Allocs: 0
+Retain: 0
+
+Unifications: 0
+Conjuncts:    0
+Disjuncts:    0
+Builtins:     0
 -- out/run/t3 --
 graph TD
   t0("root.t1 [Terminated]")
@@ -74,26 +96,6 @@ graph TD
 		$id: string
 	}]
 }
--- out/run/t1/stats --
-Leaks:  0
-Freed:  0
-Reused: 0
-Allocs: 0
-Retain: 0
-
-Unifications: 0
-Conjuncts:    0
-Disjuncts:    0
--- out/run/t2/stats --
-Leaks:  0
-Freed:  0
-Reused: 0
-Allocs: 0
-Retain: 0
-
-Unifications: 0
-Conjuncts:    0
-Disjuncts:    0
 -- out/run/t3/stats --
 Leaks:  0
 Freed:  0
@@ -104,6 +106,7 @@ Retain: 0
 Unifications: 0
 Conjuncts:    0
 Disjuncts:    0
+Builtins:     0
 -- out/run/stats/totals --
 Leaks:  0
 Freed:  0
@@ -114,3 +117,4 @@ Retain: 0
 Unifications: 0
 Conjuncts:    0
 Disjuncts:    0
+Builtins:     0

--- a/tools/flow/testdata/issue2397.txtar
+++ b/tools/flow/testdata/issue2397.txtar
@@ -43,6 +43,7 @@ Retain: 1
 Unifications: 9
 Conjuncts:    24
 Disjuncts:    12
+Builtins:     0
 -- out/run/stats/totals --
 Leaks:  0
 Freed:  11
@@ -53,3 +54,4 @@ Retain: 1
 Unifications: 9
 Conjuncts:    24
 Disjuncts:    12
+Builtins:     0

--- a/tools/flow/testdata/issue2416a.txtar
+++ b/tools/flow/testdata/issue2416a.txtar
@@ -87,6 +87,7 @@ Retain: 2
 Unifications: 40
 Conjuncts:    98
 Disjuncts:    58
+Builtins:     11
 -- out/run/t2 --
 graph TD
   t0("root.build.task.mkdir.output [Terminated]")
@@ -121,6 +122,7 @@ Retain: 2
 Unifications: 41
 Conjuncts:    104
 Disjuncts:    59
+Builtins:     11
 -- out/run/stats/totals --
 Leaks:  0
 Freed:  113
@@ -131,3 +133,4 @@ Retain: 4
 Unifications: 81
 Conjuncts:    202
 Disjuncts:    117
+Builtins:     22

--- a/tools/flow/testdata/issue2416b.txtar
+++ b/tools/flow/testdata/issue2416b.txtar
@@ -52,6 +52,7 @@ Retain: 1
 Unifications: 22
 Conjuncts:    56
 Disjuncts:    31
+Builtins:     1
 -- out/run/stats/totals --
 Leaks:  0
 Freed:  30
@@ -62,3 +63,4 @@ Retain: 1
 Unifications: 22
 Conjuncts:    56
 Disjuncts:    31
+Builtins:     1

--- a/tools/flow/testdata/issue2490.txtar
+++ b/tools/flow/testdata/issue2490.txtar
@@ -39,6 +39,7 @@ Retain: 0
 Unifications: 7
 Conjuncts:    16
 Disjuncts:    9
+Builtins:     1
 -- out/run/stats/totals --
 Leaks:  0
 Freed:  9
@@ -49,3 +50,4 @@ Retain: 0
 Unifications: 7
 Conjuncts:    16
 Disjuncts:    9
+Builtins:     1

--- a/tools/flow/testdata/issue2517.txtar
+++ b/tools/flow/testdata/issue2517.txtar
@@ -43,6 +43,7 @@ Retain: 0
 Unifications: 11
 Conjuncts:    17
 Disjuncts:    11
+Builtins:     0
 -- out/run/t2 --
 graph TD
   t0("root.prepare [Terminated]")
@@ -67,6 +68,7 @@ Retain: 0
 Unifications: 12
 Conjuncts:    21
 Disjuncts:    12
+Builtins:     0
 -- out/run/stats/totals --
 Leaks:  0
 Freed:  23
@@ -77,3 +79,4 @@ Retain: 0
 Unifications: 23
 Conjuncts:    38
 Disjuncts:    23
+Builtins:     0

--- a/tools/flow/testdata/par.txtar
+++ b/tools/flow/testdata/par.txtar
@@ -51,6 +51,17 @@ graph TD
 	val: "baz"
 	out: "baz"
 }
+-- out/run/t1/stats --
+Leaks:  0
+Freed:  20
+Reused: 16
+Allocs: 4
+Retain: 0
+
+Unifications: 20
+Conjuncts:    28
+Disjuncts:    20
+Builtins:     0
 -- out/run/t2 --
 graph TD
   t0("root.a [Terminated]")
@@ -68,6 +79,17 @@ graph TD
 	val: "foo"
 	out: "foo"
 }
+-- out/run/t2/stats --
+Leaks:  0
+Freed:  20
+Reused: 20
+Allocs: 0
+Retain: 0
+
+Unifications: 20
+Conjuncts:    32
+Disjuncts:    20
+Builtins:     0
 -- out/run/t3 --
 graph TD
   t0("root.a [Terminated]")
@@ -85,6 +107,17 @@ graph TD
 	val: "bar"
 	out: "bar"
 }
+-- out/run/t3/stats --
+Leaks:  0
+Freed:  20
+Reused: 20
+Allocs: 0
+Retain: 0
+
+Unifications: 20
+Conjuncts:    32
+Disjuncts:    20
+Builtins:     0
 -- out/run/t4 --
 graph TD
   t0("root.a [Terminated]")
@@ -100,36 +133,6 @@ graph TD
 	$id: "valToOut"
 	out: "foobarbaz"
 }
--- out/run/t1/stats --
-Leaks:  0
-Freed:  20
-Reused: 16
-Allocs: 4
-Retain: 0
-
-Unifications: 20
-Conjuncts:    28
-Disjuncts:    20
--- out/run/t2/stats --
-Leaks:  0
-Freed:  20
-Reused: 20
-Allocs: 0
-Retain: 0
-
-Unifications: 20
-Conjuncts:    32
-Disjuncts:    20
--- out/run/t3/stats --
-Leaks:  0
-Freed:  20
-Reused: 20
-Allocs: 0
-Retain: 0
-
-Unifications: 20
-Conjuncts:    32
-Disjuncts:    20
 -- out/run/t4/stats --
 Leaks:  0
 Freed:  0
@@ -140,6 +143,7 @@ Retain: 0
 Unifications: 0
 Conjuncts:    0
 Disjuncts:    0
+Builtins:     0
 -- out/run/stats/totals --
 Leaks:  0
 Freed:  60
@@ -150,3 +154,4 @@ Retain: 0
 Unifications: 60
 Conjuncts:    92
 Disjuncts:    60
+Builtins:     0

--- a/tools/flow/testdata/pkg.txtar
+++ b/tools/flow/testdata/pkg.txtar
@@ -49,6 +49,17 @@ graph TD
 	val: "foo sub"
 	out: "foo sub"
 }
+-- out/run/t1/stats --
+Leaks:  0
+Freed:  17
+Reused: 12
+Allocs: 5
+Retain: 0
+
+Unifications: 17
+Conjuncts:    28
+Disjuncts:    17
+Builtins:     0
 -- out/run/t2 --
 graph TD
   t0("root.a [Terminated]")
@@ -69,6 +80,17 @@ graph TD
 	val: "bar"
 	out: "bar"
 }
+-- out/run/t2/stats --
+Leaks:  0
+Freed:  17
+Reused: 17
+Allocs: 0
+Retain: 0
+
+Unifications: 17
+Conjuncts:    28
+Disjuncts:    17
+Builtins:     0
 -- out/run/t3 --
 graph TD
   t0("root.a [Terminated]")
@@ -83,26 +105,6 @@ graph TD
 	$id: "valToOut"
 	out: "foo subbar"
 }
--- out/run/t1/stats --
-Leaks:  0
-Freed:  17
-Reused: 12
-Allocs: 5
-Retain: 0
-
-Unifications: 17
-Conjuncts:    28
-Disjuncts:    17
--- out/run/t2/stats --
-Leaks:  0
-Freed:  17
-Reused: 17
-Allocs: 0
-Retain: 0
-
-Unifications: 17
-Conjuncts:    28
-Disjuncts:    17
 -- out/run/t3/stats --
 Leaks:  0
 Freed:  0
@@ -113,6 +115,7 @@ Retain: 0
 Unifications: 0
 Conjuncts:    0
 Disjuncts:    0
+Builtins:     0
 -- out/run/stats/totals --
 Leaks:  0
 Freed:  34
@@ -123,3 +126,4 @@ Retain: 0
 Unifications: 34
 Conjuncts:    56
 Disjuncts:    34
+Builtins:     0

--- a/tools/flow/testdata/simple.txtar
+++ b/tools/flow/testdata/simple.txtar
@@ -41,6 +41,17 @@ graph TD
 	val: "foo"
 	out: "foo"
 }
+-- out/run/t1/stats --
+Leaks:  0
+Freed:  17
+Reused: 12
+Allocs: 5
+Retain: 0
+
+Unifications: 17
+Conjuncts:    28
+Disjuncts:    17
+Builtins:     0
 -- out/run/t2 --
 graph TD
   t0("root.a [Terminated]")
@@ -61,6 +72,17 @@ graph TD
 	val: "bar"
 	out: "bar"
 }
+-- out/run/t2/stats --
+Leaks:  0
+Freed:  17
+Reused: 17
+Allocs: 0
+Retain: 0
+
+Unifications: 17
+Conjuncts:    28
+Disjuncts:    17
+Builtins:     0
 -- out/run/t3 --
 graph TD
   t0("root.a [Terminated]")
@@ -75,26 +97,6 @@ graph TD
 	$id: "valToOut"
 	out: "foobar"
 }
--- out/run/t1/stats --
-Leaks:  0
-Freed:  17
-Reused: 12
-Allocs: 5
-Retain: 0
-
-Unifications: 17
-Conjuncts:    28
-Disjuncts:    17
--- out/run/t2/stats --
-Leaks:  0
-Freed:  17
-Reused: 17
-Allocs: 0
-Retain: 0
-
-Unifications: 17
-Conjuncts:    28
-Disjuncts:    17
 -- out/run/t3/stats --
 Leaks:  0
 Freed:  0
@@ -105,6 +107,7 @@ Retain: 0
 Unifications: 0
 Conjuncts:    0
 Disjuncts:    0
+Builtins:     0
 -- out/run/stats/totals --
 Leaks:  0
 Freed:  34
@@ -115,3 +118,4 @@ Retain: 0
 Unifications: 34
 Conjuncts:    56
 Disjuncts:    34
+Builtins:     0

--- a/tools/flow/testdata/slice.txtar
+++ b/tools/flow/testdata/slice.txtar
@@ -56,6 +56,7 @@ Retain: 0
 Unifications: 17
 Conjuncts:    30
 Disjuncts:    17
+Builtins:     0
 -- out/run/t2 --
 graph TD
   t0("root[0] [Terminated]")
@@ -86,6 +87,7 @@ Retain: 0
 Unifications: 17
 Conjuncts:    33
 Disjuncts:    17
+Builtins:     0
 -- out/run/t3 --
 graph TD
   t0("root[0] [Terminated]")
@@ -110,6 +112,7 @@ Retain: 0
 Unifications: 0
 Conjuncts:    0
 Disjuncts:    0
+Builtins:     0
 -- out/run/stats/totals --
 Leaks:  0
 Freed:  34
@@ -120,3 +123,4 @@ Retain: 0
 Unifications: 34
 Conjuncts:    63
 Disjuncts:    34
+Builtins:     0

--- a/tools/flow/testdata/template.txtar
+++ b/tools/flow/testdata/template.txtar
@@ -56,6 +56,7 @@ Retain: 0
 Unifications: 25
 Conjuncts:    65
 Disjuncts:    42
+Builtins:     0
 -- out/run/t2 --
 graph TD
   t0("root.get [Terminated]")
@@ -98,6 +99,7 @@ Retain: 0
 Unifications: 25
 Conjuncts:    69
 Disjuncts:    42
+Builtins:     0
 -- out/run/stats/totals --
 Leaks:  0
 Freed:  84
@@ -108,6 +110,7 @@ Retain: 0
 Unifications: 50
 Conjuncts:    134
 Disjuncts:    84
+Builtins:     0
 -- out/run/t3 --
 graph TD
   t0("root.get [Terminated]")


### PR DESCRIPTION
Based on PR (only the last commit is important):
 - #2588

This change breaks backward compatibility, but I couldn't think of anything better.

I try explain this workaround by example `cue/testdata/eval/let_funcs.txtar`:
```cue
import "strings"
#Foo: {
	#a: string
	#b: string
	foo: strings.HasPrefix("\(#a)", #b)
}
foo: {
	let env_context = #Foo & {
		#a: "hello"
		#b: "world"
	}
	e1: env_context
	e2: env_context
	e3: env_context
	e4: env_context
	e5: env_context
	e6: env_context
	e7: env_context
	e8: env_context
}
```
In original code:
 - `let env_context` call `strings.HasPrefix` at the first time and create finazlied `*adt.Vertex` (`vertex_1`). This `*adt.Vertex` also contains `*adt.CallExpr` somewhere in conjuncts;
 - `e1: env_context` create new `*adt.Vertex` (`vertex_2`). On creating `vertex_2` executed `n.addVertexConjuncts(v, arc, false)` with `vertex_1` as `arc`;
 - `addVertexConjuncts` internally add all conjuncts from `vertex_1` to `vertex_2`;
 - `vertex_2` finalization reevaluates `*adt.CallExpr` from added conjuncts.

After this workaround `vertex_1` became data and lost conjuncts with `*adt.CallExpr` node.