### PR TITLE
internal/core/adt: add `exists` builtin func

### DIFF
--- a/cue/testdata/builtins/exists.txtar
+++ b/cue/testdata/builtins/exists.txtar
@@ -1,0 +1,120 @@
+-- in.cue --
+a: {}
+b: int
+
+c: exists(a)   // true
+d: exists(b)   // true
+e: exists(a.b) // false (b could still be defined)
+f: exists(b.c) // fatal error (b.c can never be satisfied)
+
+opt?: int
+ref_opt: exists(opt)  // false considered to be non-existing.
+
+req!: int
+ref_req: exists(req)  // false
+
+foo: {
+    a?: string
+    b?: string
+    a: "test"
+}
+
+foo_a: exists(foo.a) // true
+foo_b: exists(foo.b) // false(foo.b could still be defined)
+foo_c: exists(foo.c) // false(foo.c could still be defined)
+foo_a_x: exists(foo.a.x) // fatal error (foo.a.x can never be satisfied)
+foo_b_x: exists(foo.b.x) // fatal error (foo.b.x can never be satisfied)
+foo_c_x: exists(foo.c.x)
+foo_e: exists({a: 1, a: 2}.a) // fatal error (conflict values)
+
+-- out/compile --
+--- in.cue
+{
+  a: {}
+  b: int
+  c: exists(〈0;a〉)
+  d: exists(〈0;b〉)
+  e: exists(〈0;a〉.b)
+  f: exists(〈0;b〉.c)
+  opt?: int
+  ref_opt: exists(〈0;opt〉)
+  req!: int
+  ref_req: exists(〈0;req〉)
+  foo: {
+    a?: string
+    b?: string
+    a: "test"
+  }
+  foo_a: exists(〈0;foo〉.a)
+  foo_b: exists(〈0;foo〉.b)
+  foo_c: exists(〈0;foo〉.c)
+  foo_a_x: exists(〈0;foo〉.a.x)
+  foo_b_x: exists(〈0;foo〉.b.x)
+  foo_c_x: exists(〈0;foo〉.c.x)
+  foo_e: exists({
+    a: 1
+    a: 2
+  }.a)
+}
+-- out/eval/stats --
+Leaks:  2
+Freed:  21
+Reused: 19
+Allocs: 4
+Retain: 2
+
+Unifications: 23
+Conjuncts:    31
+Disjuncts:    22
+-- out/eval --
+Errors:
+a: conflicting values 2 and 1:
+    ./in.cue:27:19
+    ./in.cue:27:25
+f: invalid operand b (found int, want list or struct):
+    ./in.cue:7:11
+foo_a_x: invalid operand foo.a (found string, want list or struct):
+    ./in.cue:24:17
+
+Result:
+(_|_){
+  // [eval]
+  a: (struct){
+  }
+  b: (int){ int }
+  c: (bool){ true }
+  d: (bool){ true }
+  e: (bool){ false }
+  f: (_|_){
+    // [eval] f: invalid operand b (found int, want list or struct):
+    //     ./in.cue:7:11
+  }
+  opt?: (int){ int }
+  ref_opt: (bool){ false }
+  req!: (int){ int }
+  ref_req: (bool){ false }
+  foo: (struct){
+    a: (string){ "test" }
+    b?: (string){ string }
+  }
+  foo_a: (bool){ true }
+  foo_b: (bool){ false }
+  foo_c: (bool){ false }
+  foo_a_x: (_|_){
+    // [eval] foo_a_x: invalid operand foo.a (found string, want list or struct):
+    //     ./in.cue:24:17
+  }
+  foo_b_x: (_|_){
+    // [incomplete] foo_b_x: cannot reference optional field: b:
+    //     ./in.cue:25:21
+  }
+  foo_c_x: (_|_){
+    // [incomplete] foo_c_x: undefined field: c:
+    //     ./in.cue:26:21
+  }
+  foo_e: (_|_){
+    // [eval] a: conflicting values 2 and 1:
+    //     ./in.cue:27:19
+    //     ./in.cue:27:25
+  }
+}

--- a/internal/core/adt/expr.go
+++ b/internal/core/adt/expr.go
@@ -1468,6 +1468,10 @@ func (x *CallExpr) evaluate(c *OpContext, state vertexStatus) Value {
 
 		case *Bottom:
 			// TODO(errors): consider adding an argument index for this errors.
+			if b.AllowErrors {
+				args = append(args, expr)
+				continue
+			}
 			c.errs = CombineErrors(a.Source(), c.errs, v)
 
 		default:
@@ -1475,7 +1479,7 @@ func (x *CallExpr) evaluate(c *OpContext, state vertexStatus) Value {
 		}
 		c.errs = CombineErrors(a.Source(), saved, c.errs)
 	}
-	if c.HasErr() {
+	if c.HasErr() && (b == nil || !b.AllowErrors) {
 		return nil
 	}
 	if b.IsValidator(len(args)) {
@@ -1495,8 +1499,9 @@ type Builtin struct {
 	Result Kind
 	Func   func(c *OpContext, args []Value) Expr
 
-	Package Feature
-	Name    string
+	Package     Feature
+	Name        string
+	AllowErrors bool
 }
 
 type Param struct {

--- a/internal/core/compile/builtin.go
+++ b/internal/core/compile/builtin.go
@@ -192,6 +192,25 @@ var remBuiltin = &adt.Builtin{
 	},
 }
 
+var existsBuiltin = &adt.Builtin{
+	Name:        "exists",
+	Params:      []adt.Param{{Value: &adt.BasicType{K: adt.BottomKind}}},
+	Result:      adt.BoolKind,
+	AllowErrors: true,
+	Func: func(c *adt.OpContext, args []adt.Value) adt.Expr {
+		switch x := args[0].(type) {
+		case *adt.Bottom:
+			if x.IsIncomplete() && x.Permanent {
+				_ = c.Err() // clear evaluations errors
+				return &adt.Bool{B: false}
+			}
+			return x
+		default:
+			return &adt.Bool{B: x.Concreteness() >= adt.Concrete}
+		}
+	},
+}
+
 type intFunc func(c *adt.OpContext, x, y *adt.Num) adt.Value
 
 func intDivOp(c *adt.OpContext, fn intFunc, name string, args []adt.Value) adt.Value {

--- a/internal/core/compile/predeclared.go
+++ b/internal/core/compile/predeclared.go
@@ -40,6 +40,8 @@ func predeclared(n *ast.Ident) adt.Expr {
 	case "number", "__number":
 		return &adt.BasicType{Src: n, K: adt.NumKind}
 
+	case "exists", "__exists":
+		return existsBuiltin
 	case "len", "__len":
 		return lenBuiltin
 	case "close", "__close":


### PR DESCRIPTION
This PR implements `exists` buildin func from https://github.com/cue-lang/cue/issues/943 proposal.

exists(expr) :: bool (optional)

`exists` reports whether expr resolves to any value.

**Motivation**: replaces `if a.foo != _|_ {` field exists check without hiding the underlying error.