### PR TITLE
[doc] fix error in dynamic fields example

### DIFF
--- a/doc/ref/spec.md
+++ b/doc/ref/spec.md
@@ -1166,9 +1166,9 @@ A dynamic field may be marked as optional or required.
 
 ```
 Expression                             Result
-a:   "foo                              a:   "foo"
+a:   "foo"                             a:   "foo"
 b:   "bar"                             b:   "bar"
-(a): "baz"                             bar: "baz"
+(a): "baz"                             foo: "baz"
 
 (a+b): "qux"                           foobar: "qux"
 


### PR DESCRIPTION
Since `a: "foo"` is provided in the example, the result of `(a): "baz"`
is `foo: "baz"` not `bar: "baz"`.

Also add a missing quote.

Closes: #2592