### PR TITLE
protobuf: enable protobuf standard `required` mechanism

### DIFF
--- a/encoding/protobuf/parse.go
+++ b/encoding/protobuf/parse.go
@@ -796,7 +796,10 @@ func (p *optionParser) parse(options []*proto.Option) {
 			if !p.required {
 				constraint.Optional = token.NoSpace.Pos()
 			}
-
+		case "(google.api.field_behavior)":
+			if o.Constant.Source == "REQUIRED" {
+				p.required = true
+			}
 		default:
 			// TODO: dropping comments. Maybe add dummy tag?
 

--- a/encoding/protobuf/testdata/gateway.proto.out.cue
+++ b/encoding/protobuf/testdata/gateway.proto.out.cue
@@ -205,7 +205,7 @@ package v1alpha3
 
 #Gateway: {
 	// REQUIRED: A list of server specifications.
-	servers?: [...#Server] @protobuf(1,Server)
+	servers: [...#Server] @protobuf(1,Server)
 
 	// REQUIRED: One or more labels that indicate a specific set of pods/VMs
 	// on which this gateway configuration should be applied. The scope of

--- a/encoding/protobuf/testdata/istio.io/api/networking/v1alpha3/gateway.proto
+++ b/encoding/protobuf/testdata/istio.io/api/networking/v1alpha3/gateway.proto
@@ -213,7 +213,7 @@ option go_package = "istio.io/api/networking/v1alpha3"; // INLINE
 
 message Gateway {
   // REQUIRED: A list of server specifications.
-  repeated Server servers = 1;
+  repeated Server servers = 1 [(google.api.field_behavior) = REQUIRED];
 
   // REQUIRED: One or more labels that indicate a specific set of pods/VMs
   // on which this gateway configuration should be applied. The scope of

--- a/encoding/protobuf/testdata/istio.io/api/networking/v1alpha3/gateway_proto_gen.cue
+++ b/encoding/protobuf/testdata/istio.io/api/networking/v1alpha3/gateway_proto_gen.cue
@@ -205,7 +205,7 @@ package v1alpha3
 
 #Gateway: {
 	// REQUIRED: A list of server specifications.
-	servers?: [...#Server] @protobuf(1,Server)
+	servers: [...#Server] @protobuf(1,Server)
 
 	// REQUIRED: One or more labels that indicate a specific set of pods/VMs
 	// on which this gateway configuration should be applied. The scope of


### PR DESCRIPTION
See https://google.aip.dev/203. Currently, there is support for an option `(cue.opt).required`. This is fine, but requires importing the `cue.proto`, and exposes cue to the public facing API.

With this approach, the built-in field behavior mechanism can be used, which is the standard way to declare a required field in proto.