### PR TITLE
chore: gofumpt

### DIFF
--- a/cmd/cue/cmd/add.go
+++ b/cmd/cue/cmd/add.go
@@ -203,7 +203,7 @@ func (fo *originalFile) restore() error {
 	if len(fo.contents) == 0 {
 		return os.Remove(fo.filename)
 	}
-	return os.WriteFile(fo.filename, fo.contents, 0644)
+	return os.WriteFile(fo.filename, fo.contents, 0o644)
 }
 
 type fileInfo struct {
@@ -288,7 +288,7 @@ func (fi *fileInfo) appendAndCheck() (fo originalFile, err error) {
 		return originalFile{}, err
 	}
 
-	if err = os.WriteFile(fi.filename, b, 0644); err != nil {
+	if err = os.WriteFile(fi.filename, b, 0o644); err != nil {
 		// Just in case, attempt to restore original file.
 		_ = fo.restore()
 		return originalFile{}, err

--- a/cmd/cue/cmd/fix.go
+++ b/cmd/cue/cmd/fix.go
@@ -106,7 +106,7 @@ func runFixAll(cmd *Command, args []string) error {
 				errs = errors.Append(errs, errors.Promote(err, "format"))
 			}
 
-			err = os.WriteFile(f.Filename, b, 0644)
+			err = os.WriteFile(f.Filename, b, 0o644)
 			if err != nil {
 				errs = errors.Append(errs, errors.Promote(err, "write"))
 			}

--- a/cmd/cue/cmd/get_go.go
+++ b/cmd/cue/cmd/get_go.go
@@ -461,7 +461,7 @@ func (e *extractor) extractPkg(root string, p *packages.Package) error {
 		}
 	}
 
-	if err := os.MkdirAll(dir, 0777); err != nil {
+	if err := os.MkdirAll(dir, 0o777); err != nil {
 		return err
 	}
 
@@ -534,7 +534,7 @@ func (e *extractor) extractPkg(root string, p *packages.Package) error {
 		if err != nil {
 			return err
 		}
-		err = os.WriteFile(filepath.Join(dir, file), b, 0666)
+		err = os.WriteFile(filepath.Join(dir, file), b, 0o666)
 		if err != nil {
 			return err
 		}
@@ -595,7 +595,7 @@ func (e *extractor) importCUEFiles(p *packages.Package, dir, args string) error 
 				w.Write(b)
 
 				dst := filepath.Join(dir, file)
-				if err := os.WriteFile(dst, w.Bytes(), 0666); err != nil {
+				if err := os.WriteFile(dst, w.Bytes(), 0o666); err != nil {
 					return err
 				}
 			}
@@ -1342,7 +1342,7 @@ func hasFlag(tag, key, flag string, offset int) bool {
 	return false
 }
 
-func getName(name string, tag string) string {
+func getName(name, tag string) string {
 	tags := reflect.StructTag(tag)
 	for _, s := range []string{"json", "yaml"} {
 		if tag, ok := tags.Lookup(s); ok {

--- a/cmd/cue/cmd/import.go
+++ b/cmd/cue/cmd/import.go
@@ -490,8 +490,8 @@ func writeFile(p *buildPlan, f *ast.File, cueFile string) error {
 		_, err := p.cmd.OutOrStdout().Write(b)
 		return err
 	}
-	_ = os.MkdirAll(filepath.Dir(cueFile), 0755)
-	return os.WriteFile(cueFile, b, 0644)
+	_ = os.MkdirAll(filepath.Dir(cueFile), 0o755)
+	return os.WriteFile(cueFile, b, 0o644)
 }
 
 type hoister struct {
@@ -521,7 +521,6 @@ func (h *hoister) hoist(f *ast.File) {
 			return false
 		}
 		return true
-
 	}, func(c astutil.Cursor) bool {
 		switch f := c.Node().(type) {
 		case *ast.Field:

--- a/cmd/cue/cmd/mod.go
+++ b/cmd/cue/cmd/mod.go
@@ -116,7 +116,7 @@ func runModInit(cmd *Command, args []string) (err error) {
 		return fmt.Errorf("cue.mod directory already exists")
 	}
 
-	err = os.Mkdir(mod, 0755)
+	err = os.Mkdir(mod, 0o755)
 	if err != nil && !os.IsExist(err) {
 		return err
 	}
@@ -130,10 +130,10 @@ func runModInit(cmd *Command, args []string) (err error) {
 	// Set module even if it is empty, making it easier for users to fill it in.
 	_, err = fmt.Fprintf(f, "module: %q\n", module)
 
-	if err = os.Mkdir(filepath.Join(mod, "usr"), 0755); err != nil {
+	if err = os.Mkdir(filepath.Join(mod, "usr"), 0o755); err != nil {
 		return err
 	}
-	if err = os.Mkdir(filepath.Join(mod, "pkg"), 0755); err != nil {
+	if err = os.Mkdir(filepath.Join(mod, "pkg"), 0o755); err != nil {
 		return err
 	}
 
@@ -148,7 +148,7 @@ func backport(mod, cwd string) error {
 		return err
 	}
 
-	err = os.Mkdir(filepath.Join(cwd, "cue.mod"), 0755)
+	err = os.Mkdir(filepath.Join(cwd, "cue.mod"), 0o755)
 	if err != nil {
 		os.Rename(tmp, mod)
 		return err
@@ -164,10 +164,10 @@ func backport(mod, cwd string) error {
 		return err
 	}
 
-	if err = os.Mkdir(filepath.Join(mod, "usr"), 0755); err != nil {
+	if err = os.Mkdir(filepath.Join(mod, "usr"), 0o755); err != nil {
 		return err
 	}
-	if err = os.Mkdir(filepath.Join(mod, "pkg"), 0755); err != nil {
+	if err = os.Mkdir(filepath.Join(mod, "pkg"), 0o755); err != nil {
 		return err
 	}
 

--- a/cmd/cue/cmd/registry.go
+++ b/cmd/cue/cmd/registry.go
@@ -90,9 +90,7 @@ func isInsecureHost(hostPort string) bool {
 		host = hostPort
 	}
 	switch host {
-	case "localhost",
-		"127.0.0.1",
-		"::1":
+	case "localhost", "127.0.0.1", "::1":
 		return true
 	}
 	// TODO other clients have logic for RFC1918 too, amongst other

--- a/cmd/cue/cmd/script_test.go
+++ b/cmd/cue/cmd/script_test.go
@@ -99,7 +99,7 @@ func TestScript(t *testing.T) {
 			// Set up a home dir within work dir with a . prefix so that the
 			// Go/CUE pattern ./... does not descend into it.
 			home := filepath.Join(e.WorkDir, homeDirName)
-			if err := os.Mkdir(home, 0777); err != nil {
+			if err := os.Mkdir(home, 0o777); err != nil {
 				return err
 			}
 
@@ -164,8 +164,8 @@ func TestX(t *testing.T) {
 
 	for _, f := range a.Files {
 		name := filepath.Join(tmpdir, f.Name)
-		check(os.MkdirAll(filepath.Dir(name), 0777))
-		check(os.WriteFile(name, f.Data, 0666))
+		check(os.MkdirAll(filepath.Dir(name), 0o777))
+		check(os.WriteFile(name, f.Data, 0o666))
 	}
 
 	cwd, err := os.Getwd()

--- a/cmd/cue/cmd/trim.go
+++ b/cmd/cue/cmd/trim.go
@@ -174,7 +174,7 @@ func runTrim(cmd *Command, args []string) error {
 				filename = dst
 			}
 
-			err = os.WriteFile(filename, b, 0644)
+			err = os.WriteFile(filename, b, 0o644)
 			if err != nil {
 				return err
 			}

--- a/cue/ast/ast.go
+++ b/cue/ast/ast.go
@@ -870,6 +870,7 @@ func NewImport(name *Ident, importPath string) *ImportSpec {
 // Pos and End implementations for spec nodes.
 
 func (s *ImportSpec) Pos() token.Pos { return getPos(s) }
+
 func (s *ImportSpec) pos() *token.Pos {
 	if s.Name != nil {
 		return s.Name.pos()

--- a/cue/ast/ast_test.go
+++ b/cue/ast/ast_test.go
@@ -116,7 +116,8 @@ func TestNewStruct(t *testing.T) {
 	// foo
 
 	...
-}`}, {
+}`,
+	}, {
 		input: []any{
 			&ast.LetClause{Ident: ast.NewIdent("foo"), Expr: ast.NewIdent("bar")},
 			ast.Label(ast.NewString("bar")), ast.NewString("baz"),
@@ -129,7 +130,8 @@ func TestNewStruct(t *testing.T) {
 	let foo = bar
 	"bar": "baz"
 	"a":   "b"
-}`}, {
+}`,
+	}, {
 		input: []any{
 			ast.NewIdent("opt"), token.OPTION, ast.NewString("foo"),
 			ast.NewIdent("req"), token.NOT, ast.NewString("bar"),
@@ -137,11 +139,13 @@ func TestNewStruct(t *testing.T) {
 		want: `{
 	opt?: "foo"
 	req!: "bar"
-}`}, {
+}`,
+	}, {
 		input: []any{ast.Embed(ast.NewBool(true))},
 		want: `{
 	true
-}`}}
+}`,
+	}}
 	// TODO(tdtest): use cuetest.Run when supported.
 	tdtest.Run(t, testCases, func(t *cuetest.T, tc *testCase) {
 		s := ast.NewStruct(tc.input...)

--- a/cue/ast/astutil/apply_test.go
+++ b/cue/ast/astutil/apply_test.go
@@ -132,7 +132,8 @@ everywhere: new
 				}
 			}
 			return true
-		}}, {
+		},
+	}, {
 		name: "templates",
 		in: `
 				foo: {

--- a/cue/ast/astutil/sanitize_test.go
+++ b/cue/ast/astutil/sanitize_test.go
@@ -42,7 +42,8 @@ func TestSanitize(t *testing.T) {
 						ast.NewIdent("list"), ast.NewCall(
 							ast.NewSel(&ast.Ident{Name: "list", Node: spec},
 								"Min")),
-					)},
+					),
+				},
 			}}
 		}(),
 		want: `import (

--- a/cue/ast/ident.go
+++ b/cue/ast/ident.go
@@ -188,7 +188,6 @@ func LabelName(l Label) (name string, isIdent bool, err error) {
 		isIdent = false
 	}
 	return name, isIdent, err
-
 }
 
 // ErrIsExpression reports whether a label is an expression.

--- a/cue/attribute_test.go
+++ b/cue/attribute_test.go
@@ -101,7 +101,6 @@ func TestAttributes(t *testing.T) {
 			if got != tc.out {
 				t.Errorf("got %v; want %v", got, tc.out)
 			}
-
 		})
 	}
 }

--- a/cue/build_test.go
+++ b/cue/build_test.go
@@ -90,25 +90,30 @@ func TestBuild(t *testing.T) {
 		insts(&bimport{"", files(`test: "ok"`)}),
 		`{test:"ok"}`,
 	}, {
-		insts(&bimport{"",
+		insts(&bimport{
+			"",
 			files(
 				`package test
 
 				import "math"
 
-				"Pi: \(math.Pi)!"`)}),
+				"Pi: \(math.Pi)!"`),
+		}),
 		`"Pi: 3.14159265358979323846264338327950288419716939937510582097494459!"`,
 	}, {
-		insts(&bimport{"",
+		insts(&bimport{
+			"",
 			files(
 				`package test
 
 				import math2 "math"
 
-				"Pi: \(math2.Pi)!"`)}),
+				"Pi: \(math2.Pi)!"`),
+		}),
 		`"Pi: 3.14159265358979323846264338327950288419716939937510582097494459!"`,
 	}, {
-		insts(pkg1, &bimport{"",
+		insts(pkg1, &bimport{
+			"",
 			files(
 				`package test
 
@@ -118,7 +123,8 @@ func TestBuild(t *testing.T) {
 		}),
 		`"Hello World!"`,
 	}, {
-		insts(pkg1, &bimport{"",
+		insts(pkg1, &bimport{
+			"",
 			files(
 				`package test
 
@@ -128,7 +134,8 @@ func TestBuild(t *testing.T) {
 		}),
 		`"Hello World!"`,
 	}, {
-		insts(pkg1, &bimport{"",
+		insts(pkg1, &bimport{
+			"",
 			files(
 				`package test
 
@@ -139,7 +146,8 @@ func TestBuild(t *testing.T) {
 		}),
 		`"Hello World!"`,
 	}, {
-		insts(pkg1, pkg2, &bimport{"",
+		insts(pkg1, pkg2, &bimport{
+			"",
 			files(
 				`package test
 
@@ -151,7 +159,8 @@ func TestBuild(t *testing.T) {
 		}),
 		`imported and not used: "pkg1" as bar (and 1 more errors)`,
 	}, {
-		insts(pkg2, &bimport{"",
+		insts(pkg2, &bimport{
+			"",
 			files(
 				`package test
 
@@ -162,7 +171,8 @@ func TestBuild(t *testing.T) {
 		`imported and not used: "mod.test/foo/pkg2:pkg" (and 1 more errors)`,
 		// `file0.cue:5:14: unresolved reference pkg2`,
 	}, {
-		insts(pkg2, &bimport{"",
+		insts(pkg2, &bimport{
+			"",
 			files(
 				`package test
 
@@ -172,7 +182,8 @@ func TestBuild(t *testing.T) {
 		}),
 		`"Hello 12!"`,
 	}, {
-		insts(pkg3, &bimport{"",
+		insts(pkg3, &bimport{
+			"",
 			files(
 				`package test
 
@@ -182,7 +193,8 @@ func TestBuild(t *testing.T) {
 		}),
 		`"Hello 2!"`,
 	}, {
-		insts(pkg3, &bimport{"",
+		insts(pkg3, &bimport{
+			"",
 			files(
 				`package test
 

--- a/cue/builtin_test.go
+++ b/cue/builtin_test.go
@@ -25,12 +25,14 @@ import (
 
 func TestBuiltins(t *testing.T) {
 	test := func(pkg, expr string) []*bimport {
-		return []*bimport{{"",
+		return []*bimport{{
+			"",
 			[]string{fmt.Sprintf("import %q\n(%s)", pkg, expr)},
 		}}
 	}
 	testExpr := func(expr string) []*bimport {
-		return []*bimport{{"",
+		return []*bimport{{
+			"",
 			[]string{fmt.Sprintf("(%s)", expr)},
 		}}
 	}
@@ -140,7 +142,8 @@ func TestSingleBuiltin(t *testing.T) {
 	t.Skip("error message")
 
 	test := func(pkg, expr string) []*bimport {
-		return []*bimport{{"",
+		return []*bimport{{
+			"",
 			[]string{fmt.Sprintf("import %q\n(%s)", pkg, expr)},
 		}}
 	}

--- a/cue/decode.go
+++ b/cue/decode.go
@@ -61,7 +61,8 @@ func incompleteError(v Value) errors.Error {
 		err: &adt.Bottom{
 			Code: adt.IncompleteError,
 			Err: errors.Newf(v.Pos(),
-				"cannot convert non-concrete value %v", v)},
+				"cannot convert non-concrete value %v", v),
+		},
 	}
 }
 

--- a/cue/decode_test.go
+++ b/cue/decode_test.go
@@ -49,7 +49,6 @@ func TestDecode(t *testing.T) {
 		dst:   &[]int{1},
 		want:  []int(nil),
 	}, {
-
 		value: `1`,
 		err:   "cannot decode into unsettable value",
 	}, {
@@ -122,8 +121,10 @@ func TestDecode(t *testing.T) {
 		// allocate map
 		value: `{a:1,m:{a: 3}}`,
 		dst:   &fields{},
-		want: fields{A: 1,
-			M: map[string]interface{}{"a": int(3)}},
+		want: fields{
+			A: 1,
+			M: map[string]interface{}{"a": int(3)},
+		},
 	}, {
 		// indirect int
 		value: `{p: 1}`,
@@ -187,7 +188,8 @@ func TestDecode(t *testing.T) {
 		dst:   &map[string]interface{}{},
 		want: map[string]interface{}{
 			"a": 1, "b": 2, "c": true,
-			"d": map[string]interface{}{"e": 2}},
+			"d": map[string]interface{}{"e": 2},
+		},
 	}, {
 		value: `{a: b: *2 | int}`,
 		dst:   &map[string]interface{}{},

--- a/cue/format.go
+++ b/cue/format.go
@@ -136,7 +136,6 @@ func (v Value) Format(state fmt.State, verb rune) {
 }
 
 func formatCUE(state fmt.State, v Value, showDocs, showAll bool) {
-
 	pkgPath := v.instance().ID()
 
 	p := *export.Simplified

--- a/cue/format/format_test.go
+++ b/cue/format/format_test.go
@@ -135,7 +135,7 @@ func runcheck(t *testing.T, source, golden string, mode checkMode) {
 
 	// update golden files if necessary
 	if cuetest.UpdateGoldenFiles {
-		if err := os.WriteFile(golden, res, 0644); err != nil {
+		if err := os.WriteFile(golden, res, 0o644); err != nil {
 			t.Error(err)
 		}
 		return
@@ -210,7 +210,7 @@ func TestFiles(t *testing.T) {
 			t.Parallel()
 			check(t, source, golden, mode)
 			// TODO(gri) check that golden is idempotent
-			//check(t, golden, golden, e.mode)
+			// check(t, golden, golden, e.mode)
 		})
 	}
 }
@@ -278,7 +278,6 @@ func TestNodes(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 // Verify that the printer doesn't crash if the AST contains BadXXX nodes.
@@ -294,6 +293,7 @@ func TestBadNodes(t *testing.T) {
 		t.Errorf("got %q, expected %q", string(b), res)
 	}
 }
+
 func TestPackage(t *testing.T) {
 	f := &ast.File{
 		Decls: []ast.Decl{

--- a/cue/format/node.go
+++ b/cue/format/node.go
@@ -515,7 +515,6 @@ func (f *formatter) expr1(expr ast.Expr, prec1, depth int) {
 }
 
 func (f *formatter) exprRaw(expr ast.Expr, prec1, depth int) {
-
 	switch x := expr.(type) {
 	case *ast.BadExpr:
 		f.print(x.From, "_|_")

--- a/cue/interpreter/wasm/wasm_test.go
+++ b/cue/interpreter/wasm/wasm_test.go
@@ -95,17 +95,17 @@ func copyWasmFiles(t *testing.T, dstDir, srcDir string) {
 
 func copyFile(t *testing.T, dst, src string) {
 	buf := must(os.ReadFile(src))(t)
-	err := os.WriteFile(dst, buf, 0664)
+	err := os.WriteFile(dst, buf, 0o664)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func check(t *testing.T, dir string, got string) {
+func check(t *testing.T, dir, got string) {
 	golden := filepath.Join("testdata", dir) + ".golden"
 
 	if cuetest.UpdateGoldenFiles {
-		os.WriteFile(golden, []byte(got), 0644)
+		os.WriteFile(golden, []byte(got), 0o644)
 	}
 
 	want := string(must(os.ReadFile(golden))(t))

--- a/cue/literal/quote_test.go
+++ b/cue/literal/quote_test.go
@@ -32,8 +32,10 @@ func TestQuote(t *testing.T) {
 		{form: String, in: "\x00", out: `"\u0000"`},
 		{form: String, in: "abc\xffdef", out: `"abc�def"`, lossy: true},
 		{form: Bytes, in: "abc\xffdef", out: `'abc\xffdef'`},
-		{form: String.WithASCIIOnly(),
-			in: "abc\xffdef", out: `"abc\ufffddef"`, lossy: true},
+		{
+			form: String.WithASCIIOnly(),
+			in:   "abc\xffdef", out: `"abc\ufffddef"`, lossy: true,
+		},
 		{form: String, in: "\a\b\f\r\n\t\v", out: `"\a\b\f\r\n\t\v"`},
 		{form: String, in: "\"", out: `"\""`},
 		{form: String, in: "\\", out: `"\\"`},

--- a/cue/literal/string_test.go
+++ b/cue/literal/string_test.go
@@ -43,9 +43,11 @@ func TestUnquote(t *testing.T) {
 		{`"""` + "\n\raaa\n\rbbb\n\r" + `"""`, "aaa\nbbb", nil},
 		{`'\a\b\f\n\r\t\v\'\\\/'`, "\a\b\f\n\r\t\v'\\/", nil},
 		{`"\a\b\f\n\r\t\v\"\\\/"`, "\a\b\f\n\r\t\v\"\\/", nil},
-		{`#"The sequence "\U0001F604" renders as \#U0001F604."#`,
+		{
+			`#"The sequence "\U0001F604" renders as \#U0001F604."#`,
 			`The sequence "\U0001F604" renders as 😄.`,
-			nil},
+			nil,
+		},
 		{`"  \U00010FfF"`, "  \U00010fff", nil},
 		{`"\u0061 "`, "a ", nil},
 		{`'\x61\x55'`, "\x61\x55", nil},

--- a/cue/load/fs.go
+++ b/cue/load/fs.go
@@ -39,7 +39,7 @@ type overlayFile struct {
 
 func (f *overlayFile) Name() string       { return f.basename }
 func (f *overlayFile) Size() int64        { return int64(len(f.contents)) }
-func (f *overlayFile) Mode() os.FileMode  { return 0644 }
+func (f *overlayFile) Mode() os.FileMode  { return 0o644 }
 func (f *overlayFile) ModTime() time.Time { return f.modtime }
 func (f *overlayFile) IsDir() bool        { return f.isDir }
 func (f *overlayFile) Sys() interface{}   { return nil }
@@ -257,7 +257,6 @@ func (fs *fileSystem) walk(root string, f walkFunc) error {
 		return nil
 	}
 	return err
-
 }
 
 func (fs *fileSystem) walkRec(path string, entry iofs.DirEntry, f walkFunc) errors.Error {

--- a/cue/load/loader.go
+++ b/cue/load/loader.go
@@ -127,7 +127,7 @@ func (l *loader) cueFilesPackage(files []*build.File) *build.Instance {
 	_ = pkg.Complete()
 	l.stk.Pop()
 	pkg.User = true
-	//pkg.LocalPrefix = dirToImportPath(dir)
+	// pkg.LocalPrefix = dirToImportPath(dir)
 	pkg.DisplayPath = "command-line-arguments"
 
 	return pkg

--- a/cue/load/loader_common.go
+++ b/cue/load/loader_common.go
@@ -447,8 +447,7 @@ func isLocalImport(path string) bool {
 func warnUnmatched(matches []*match) {
 	for _, m := range matches {
 		if len(m.Pkgs) == 0 {
-			m.Err =
-				errors.Newf(token.NoPos, "cue: %q matched no packages\n", m.Pattern)
+			m.Err = errors.Newf(token.NoPos, "cue: %q matched no packages\n", m.Pattern)
 		}
 	}
 }

--- a/cue/load/loader_test.go
+++ b/cue/load/loader_test.go
@@ -76,7 +76,8 @@ display:.
 files:
     $CWD/testdata/testmod/test.cue
 imports:
-    mod.test/test/sub: $CWD/testdata/testmod/sub/sub.cue`}, {
+    mod.test/test/sub: $CWD/testdata/testmod/sub/sub.cue`,
+	}, {
 		// Even though the directory is called testdata, the last path in
 		// the module is test. So "package test" is correctly the default
 		// package of this directory.
@@ -90,7 +91,8 @@ display:.
 files:
     $CWD/testdata/testmod/test.cue
 imports:
-    mod.test/test/sub: $CWD/testdata/testmod/sub/sub.cue`}, {
+    mod.test/test/sub: $CWD/testdata/testmod/sub/sub.cue`,
+	}, {
 		// TODO:
 		// - path incorrect, should be mod.test/test/other:main.
 		cfg:  dirCfg,
@@ -101,7 +103,8 @@ path:   ""
 module: mod.test/test
 root:   $CWD/testdata/testmod
 dir:    ""
-display:""`}, {
+display:""`,
+	}, {
 		cfg:  dirCfg,
 		args: args("./anon"),
 		want: `err:    build constraints exclude all CUE files in ./anon:
@@ -110,7 +113,8 @@ path:   mod.test/test/anon
 module: mod.test/test
 root:   $CWD/testdata/testmod
 dir:    $CWD/testdata/testmod/anon
-display:./anon`}, {
+display:./anon`,
+	}, {
 		// TODO:
 		// - paths are incorrect, should be mod.test/test/other:main.
 		cfg:  dirCfg,
@@ -123,7 +127,8 @@ root:   $CWD/testdata/testmod
 dir:    $CWD/testdata/testmod/other
 display:./other
 files:
-    $CWD/testdata/testmod/other/main.cue`}, {
+    $CWD/testdata/testmod/other/main.cue`,
+	}, {
 		// TODO:
 		// - incorrect path, should be mod.test/test/hello:test
 		cfg:  dirCfg,
@@ -137,7 +142,8 @@ files:
     $CWD/testdata/testmod/test.cue
     $CWD/testdata/testmod/hello/test.cue
 imports:
-    mod.test/test/sub: $CWD/testdata/testmod/sub/sub.cue`}, {
+    mod.test/test/sub: $CWD/testdata/testmod/sub/sub.cue`,
+	}, {
 		// TODO:
 		// - incorrect path, should be mod.test/test/hello:test
 		cfg:  dirCfg,
@@ -151,7 +157,8 @@ files:
     $CWD/testdata/testmod/test.cue
     $CWD/testdata/testmod/hello/test.cue
 imports:
-    mod.test/test/sub: $CWD/testdata/testmod/sub/sub.cue`}, {
+    mod.test/test/sub: $CWD/testdata/testmod/sub/sub.cue`,
+	}, {
 		// TODO:
 		// - incorrect path, should be mod.test/test/hello:test
 		cfg:  dirCfg,
@@ -164,7 +171,8 @@ path:   mod.test/test/hello:nonexist
 module: mod.test/test
 root:   $CWD/testdata/testmod
 dir:    $CWD/testdata/testmod/hello
-display:mod.test/test/hello:nonexist`}, {
+display:mod.test/test/hello:nonexist`,
+	}, {
 		cfg:  dirCfg,
 		args: args("./anon.cue", "./other/anon.cue"),
 		want: `path:   ""
@@ -174,7 +182,8 @@ dir:    $CWD/testdata/testmod
 display:command-line-arguments
 files:
     $CWD/testdata/testmod/anon.cue
-    $CWD/testdata/testmod/other/anon.cue`}, {
+    $CWD/testdata/testmod/other/anon.cue`,
+	}, {
 		cfg: dirCfg,
 		// Absolute file is normalized.
 		args: args(filepath.Join(testMod("testmod"), "anon.cue")),
@@ -184,7 +193,8 @@ root:   $CWD/testdata/testmod
 dir:    $CWD/testdata/testmod
 display:command-line-arguments
 files:
-    $CWD/testdata/testmod/anon.cue`}, {
+    $CWD/testdata/testmod/anon.cue`,
+	}, {
 		cfg:  dirCfg,
 		args: args("-"),
 		want: `path:   ""
@@ -193,7 +203,8 @@ root:   $CWD/testdata/testmod
 dir:    $CWD/testdata/testmod
 display:command-line-arguments
 files:
-    -`}, {
+    -`,
+	}, {
 		// NOTE: dir should probably be set to $CWD/testdata, but either way.
 		cfg:  dirCfg,
 		args: args("non-existing"),
@@ -224,7 +235,8 @@ files:
     $CWD/testdata/testmod/imports/imports.cue
 imports:
     mod.test/catch: $CWD/testdata/testmod/cue.mod/pkg/mod.test/catch/catch.cue
-    mod.test/helper:helper1: $CWD/testdata/testmod/cue.mod/pkg/mod.test/helper/helper1.cue`}, {
+    mod.test/helper:helper1: $CWD/testdata/testmod/cue.mod/pkg/mod.test/helper/helper1.cue`,
+	}, {
 		cfg:  dirCfg,
 		args: args("./toolonly"),
 		want: `path:   mod.test/test/toolonly:foo
@@ -233,7 +245,8 @@ root:   $CWD/testdata/testmod
 dir:    $CWD/testdata/testmod/toolonly
 display:./toolonly
 files:
-    $CWD/testdata/testmod/toolonly/foo_tool.cue`}, {
+    $CWD/testdata/testmod/toolonly/foo_tool.cue`,
+	}, {
 		cfg: &Config{
 			Dir: testdataDir,
 		},
@@ -246,7 +259,8 @@ path:   mod.test/test/toolonly:foo
 module: mod.test/test
 root:   $CWD/testdata/testmod
 dir:    $CWD/testdata/testmod/toolonly
-display:./toolonly`}, {
+display:./toolonly`,
+	}, {
 		cfg: &Config{
 			Dir:  testdataDir,
 			Tags: []string{"prod"},
@@ -258,7 +272,8 @@ root:   $CWD/testdata/testmod
 dir:    $CWD/testdata/testmod/tags
 display:./tags
 files:
-    $CWD/testdata/testmod/tags/prod.cue`}, {
+    $CWD/testdata/testmod/tags/prod.cue`,
+	}, {
 		cfg: &Config{
 			Dir:  testdataDir,
 			Tags: []string{"prod", "foo=bar"},
@@ -270,7 +285,8 @@ root:   $CWD/testdata/testmod
 dir:    $CWD/testdata/testmod/tags
 display:./tags
 files:
-    $CWD/testdata/testmod/tags/prod.cue`}, {
+    $CWD/testdata/testmod/tags/prod.cue`,
+	}, {
 		cfg: &Config{
 			Dir:  testdataDir,
 			Tags: []string{"prod"},
@@ -285,7 +301,8 @@ path:   mod.test/test/tagsbad
 module: mod.test/test
 root:   $CWD/testdata/testmod
 dir:    $CWD/testdata/testmod/tagsbad
-display:./tagsbad`}, {
+display:./tagsbad`,
+	}, {
 		cfg: &Config{
 			Dir: testdataDir,
 		},
@@ -300,7 +317,8 @@ root:   $CWD/testdata/testmod
 dir:    $CWD/testdata/testmod/cycle
 display:./cycle
 files:
-    $CWD/testdata/testmod/cycle/cycle.cue`}}
+    $CWD/testdata/testmod/cycle/cycle.cue`,
+	}}
 	tdtest.Run(t, testCases, func(t *tdtest.T, tc *loadTest) {
 		pkgs := Instances(tc.args, tc.cfg)
 
@@ -329,7 +347,8 @@ var pkgInfo = template.Must(template.New("pkg").Funcs(template.FuncMap{
 		})
 		s = strings.TrimSuffix(s, "\n")
 		return s
-	}}).Parse(`
+	},
+}).Parse(`
 {{- range . -}}
 {{- if .Err}}err:    {{errordetails .Err}}{{end}}
 path:   {{if .ImportPath}}{{.ImportPath}}{{else}}""{{end}}

--- a/cue/load/match.go
+++ b/cue/load/match.go
@@ -35,10 +35,12 @@ type match struct {
 
 var errExclude = errors.New("file rejected")
 
-type cueError = errors.Error
-type excludeError struct {
-	cueError
-}
+type (
+	cueError     = errors.Error
+	excludeError struct {
+		cueError
+	}
+)
 
 func (e excludeError) Is(err error) bool { return err == errExclude }
 

--- a/cue/marshal.go
+++ b/cue/marshal.go
@@ -217,5 +217,4 @@ func (r *Runtime) Marshal(instances ...*Instance) (b []byte, err error) {
 	}
 
 	return buf.Bytes(), nil
-
 }

--- a/cue/marshal_test.go
+++ b/cue/marshal_test.go
@@ -55,7 +55,8 @@ func TestMarshalling(t *testing.T) {
 		import "strings"
 
 		a: strings.TrimSpace("  Hello world!  ")
-		`}}
+		`,
+	}}
 	for _, tc := range testCases {
 		t.Run(tc.filename, func(t *testing.T) {
 			r := &Runtime{}
@@ -124,16 +125,19 @@ func TestMarshalMultiPackage(t *testing.T) {
 		insts(&instanceData{true, "", files(`test: "ok"`)}),
 		`{test: "ok"}`,
 	}, {
-		insts(&instanceData{true, "",
+		insts(&instanceData{
+			true, "",
 			files(
 				`package test
 
 		import math2 "math"
 
-		"Pi: \(math2.Pi)!"`)}),
+		"Pi: \(math2.Pi)!"`),
+		}),
 		`"Pi: 3.14159265358979323846264338327950288419716939937510582097494459!"`,
 	}, {
-		insts(pkg1, &instanceData{true, "",
+		insts(pkg1, &instanceData{
+			true, "",
 			files(
 				`package test
 
@@ -143,7 +147,8 @@ func TestMarshalMultiPackage(t *testing.T) {
 		}),
 		`"Hello World!"`,
 	}, {
-		insts(pkg1, &instanceData{true, "",
+		insts(pkg1, &instanceData{
+			true, "",
 			files(
 				`package test
 
@@ -154,7 +159,8 @@ func TestMarshalMultiPackage(t *testing.T) {
 		}),
 		`"Hello World!"`,
 	}, {
-		insts(pkg2, &instanceData{true, "",
+		insts(pkg2, &instanceData{
+			true, "",
 			files(
 				`package test
 

--- a/cue/parser/interface.go
+++ b/cue/parser/interface.go
@@ -157,7 +157,6 @@ const (
 // representing the fragments of erroneous source code). Multiple errors
 // are returned via a ErrorList which is sorted by file position.
 func ParseFile(filename string, src interface{}, mode ...Option) (f *ast.File, err error) {
-
 	// get source
 	text, err := source.Read(filename, src)
 	if err != nil {

--- a/cue/parser/parser.go
+++ b/cue/parser/parser.go
@@ -634,7 +634,8 @@ func (p *parser) parseOperand() (expr ast.Expr) {
 		return &ast.ParenExpr{
 			Lparen: lparen,
 			X:      x,
-			Rparen: rparen}
+			Rparen: rparen,
+		}
 
 	default:
 		if p.tok.IsKeyword() {
@@ -686,14 +687,16 @@ func (p *parser) parseIndexOrSlice(x ast.Expr) (expr ast.Expr) {
 			Lbrack: lbrack,
 			Low:    index[0],
 			High:   index[1],
-			Rbrack: rbrack}
+			Rbrack: rbrack,
+		}
 	}
 
 	return &ast.IndexExpr{
 		X:      x,
 		Lbrack: lbrack,
 		Index:  index[0],
-		Rbrack: rbrack}
+		Rbrack: rbrack,
+	}
 }
 
 func (p *parser) parseCallOrConversion(fun ast.Expr) (expr *ast.CallExpr) {
@@ -724,7 +727,8 @@ func (p *parser) parseCallOrConversion(fun ast.Expr) (expr *ast.CallExpr) {
 		Fun:    fun,
 		Lparen: lparen,
 		Args:   list,
-		Rparen: rparen}
+		Rparen: rparen,
+	}
 }
 
 // TODO: inline this function in parseFieldList once we no longer user comment
@@ -1251,7 +1255,8 @@ func (p *parser) parseList() (expr ast.Expr) {
 	return &ast.ListLit{
 		Lbrack: lbrack,
 		Elts:   elts,
-		Rbrack: rbrack}
+		Rbrack: rbrack,
+	}
 }
 
 func (p *parser) parseListElements() (list []ast.Expr) {
@@ -1512,7 +1517,8 @@ func (p *parser) parseBinaryExprTail(prec1 int, x ast.Expr) ast.Expr {
 			OpPos: pos,
 			Op:    op,
 			// Treat nested expressions as RHS.
-			Y: p.checkExpr(p.parseBinaryExpr(prec + 1))})
+			Y: p.checkExpr(p.parseBinaryExpr(prec + 1)),
+		})
 	}
 }
 

--- a/cue/parser/parser_test.go
+++ b/cue/parser/parser_test.go
@@ -24,7 +24,6 @@ import (
 
 func TestParse(t *testing.T) {
 	testCases := []struct{ desc, in, out string }{{
-
 		"ellipsis in structs",
 		`#Def: {
 			b: "2"
@@ -42,7 +41,6 @@ func TestParse(t *testing.T) {
 		`,
 		`#Def: {b: "2", ...}, ..., #Def2: {..., b: "2"}, #Def3: {..., _}, ...`,
 	}, {
-
 		"empty file", "", "",
 	}, {
 		"empty struct", "{}", "{}",
@@ -698,20 +696,32 @@ bar: 2
 
 func TestStrict(t *testing.T) {
 	testCases := []struct{ desc, in string }{
-		{"block comments",
-			`a: 1 /* a */`},
-		{"space separator",
-			`a b c: 2`},
-		{"reserved identifiers",
-			`__foo: 3`},
-		{"old-style alias 1",
-			`X=3`},
-		{"old-style alias 2",
-			`X={}`},
+		{
+			"block comments",
+			`a: 1 /* a */`,
+		},
+		{
+			"space separator",
+			`a b c: 2`,
+		},
+		{
+			"reserved identifiers",
+			`__foo: 3`,
+		},
+		{
+			"old-style alias 1",
+			`X=3`,
+		},
+		{
+			"old-style alias 2",
+			`X={}`,
+		},
 
 		// Not yet supported
-		{"additional typed not yet supported",
-			`{...int}`},
+		{
+			"additional typed not yet supported",
+			`{...int}`,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -786,7 +796,7 @@ func TestParseExpr(t *testing.T) {
 }
 
 func TestImports(t *testing.T) {
-	var imports = map[string]bool{
+	imports := map[string]bool{
 		`"a"`:        true,
 		`"a/b"`:      true,
 		`"a.b"`:      true,

--- a/cue/path.go
+++ b/cue/path.go
@@ -353,7 +353,8 @@ func toSelectors(expr ast.Expr) []Selector {
 		if b, ok := x.Index.(*ast.BasicLit); !ok {
 			sel = Selector{pathError{
 				errors.Newf(token.NoPos, "non-constant expression %s",
-					astinternal.DebugStr(x.Index))}}
+					astinternal.DebugStr(x.Index)),
+			}}
 		} else {
 			sel = basicLitSelector(b)
 		}
@@ -411,7 +412,8 @@ func basicLitSelector(b *ast.BasicLit) Selector {
 		info, _, _, _ := literal.ParseQuotes(b.Value, b.Value)
 		if !info.IsDouble() {
 			return Selector{pathError{
-				errors.Newf(token.NoPos, "invalid string index %s", b.Value)}}
+				errors.Newf(token.NoPos, "invalid string index %s", b.Value),
+			}}
 		}
 		s, _ := literal.Unquote(b.Value)
 		return Selector{stringSelector(s)}
@@ -430,8 +432,9 @@ func Label(label ast.Label) Selector {
 		switch s := x.Name; {
 		case strings.HasPrefix(s, "_"):
 			// TODO: extract package from a bound identifier.
-			return Selector{pathError{errors.Newf(token.NoPos,
-				"invalid path: hidden label %s not allowed", s),
+			return Selector{pathError{
+				errors.Newf(token.NoPos,
+					"invalid path: hidden label %s not allowed", s),
 			}}
 		case strings.HasPrefix(s, "#"):
 			return Selector{definitionSelector(x.Name)}

--- a/cue/path_test.go
+++ b/cue/path_test.go
@@ -45,7 +45,6 @@ func TestPaths(t *testing.T) {
 		out:  "int",
 		str:  "list.[_]",
 	}, {
-
 		path: MakePath(Def("#Foo"), Str("a"), Str("b")),
 		out:  "1",
 		str:  "#Foo.a.b",

--- a/cue/scanner/scanner_test.go
+++ b/cue/scanner/scanner_test.go
@@ -841,7 +841,7 @@ func TestScanErrors(t *testing.T) {
 
 // Verify that no comments show up as literal values when skipping comments.
 func TestNoLiteralComments(t *testing.T) {
-	var src = `
+	src := `
 		a: {
 			A: 1 // foo
 		}

--- a/cue/syntax_test.go
+++ b/cue/syntax_test.go
@@ -94,7 +94,8 @@ func TestSyntax(t *testing.T) {
 	let T = {
 		name: string
 	}
-}`}, {
+}`,
+	}, {
 		// Structural errors (and worse) are reported as is.
 		name: "structural error",
 		in: `

--- a/cue/token/position.go
+++ b/cue/token/position.go
@@ -152,7 +152,6 @@ func (p RelPos) Pos() Pos {
 // HasRelPos repors whether p has a relative position.
 func (p Pos) HasRelPos() bool {
 	return p.offset&relMask != 0
-
 }
 
 func (p Pos) Before(q Pos) bool {

--- a/cue/types.go
+++ b/cue/types.go
@@ -1259,7 +1259,6 @@ func (v Value) Len() Value {
 	}
 	const msg = "len not supported for type %v"
 	return remakeValue(v, nil, mkErr(v.idx, v.v, msg, v.Kind()))
-
 }
 
 // Elem returns the value of undefined element types of lists and structs.
@@ -1895,7 +1894,7 @@ func (v Value) Unify(w Value) Value {
 //
 // UnifyAccept is used to piecemeal unify individual conjuncts obtained from
 // accept without violating closedness rules.
-func (v Value) UnifyAccept(w Value, accept Value) Value {
+func (v Value) UnifyAccept(w, accept Value) Value {
 	if v.v == nil {
 		return w
 	}
@@ -2302,7 +2301,6 @@ func (v Value) Expr() (Op, []Value) {
 
 	if v.v.IsData() {
 		expr = v.v.Value()
-
 	} else {
 		switch len(v.v.Conjuncts) {
 		case 0:

--- a/cue/types_test.go
+++ b/cue/types_test.go
@@ -943,7 +943,7 @@ func TestFieldType(t *testing.T) {
 }
 
 func TestLookup(t *testing.T) {
-	var runtime = new(Runtime)
+	runtime := new(Runtime)
 	inst, err := runtime.Compile("x.cue", `
 #V: {
 	x: int
@@ -1129,7 +1129,6 @@ func TestFill2(t *testing.T) {
 		b: int
 	}
 	`)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3255,7 +3254,6 @@ func TestPathCorrection(t *testing.T) {
 		},
 		want: "a",
 	}, {
-
 		// TODO: embedding: have field operators.
 		input: `
 			a: {
@@ -3270,7 +3268,6 @@ func TestPathCorrection(t *testing.T) {
 		},
 		want: "a.c",
 	}, {
-
 		// TODO: implement proper Elem()
 		input: `
 			a: b: [...T]
@@ -3358,7 +3355,6 @@ func TestPathCorrection(t *testing.T) {
 			return v
 		},
 	}, {
-
 		input: `
 		package foo
 
@@ -3379,7 +3375,6 @@ func TestPathCorrection(t *testing.T) {
 			return v
 		},
 	}, {
-
 		// TODO: record additionalItems in list
 		input: `
 			package foo
@@ -3472,7 +3467,6 @@ func TestPathCorrection(t *testing.T) {
 			if gotPath != tc.want {
 				t.Errorf("got path %s; want %s", gotPath, tc.want)
 			}
-
 		})
 	}
 }
@@ -3705,7 +3699,7 @@ func TestExpr(t *testing.T) {
 		input: `v: and([])`,
 		want:  `_`,
 	}, {
-		//Issue #1245
+		// Issue #1245
 		input: `
 				x: *4 | int
 				v: x | *7

--- a/cuego/cuego.go
+++ b/cuego/cuego.go
@@ -197,7 +197,6 @@ func fromGoValue(x interface{}, nilIsNull bool) (v cue.Value, err error) {
 	// v = instance.Eval(expr)
 	// mutex.Unlock()
 	// return v, nil
-
 }
 
 func fromGoType(x interface{}) cue.Value {

--- a/cuego/cuego_test.go
+++ b/cuego/cuego_test.go
@@ -31,6 +31,7 @@ func checkErr(t *testing.T, got error, want string) {
 		t.Errorf("error: got %v; want %v", got, want)
 	}
 }
+
 func TestValidate(t *testing.T) {
 	fail := "some error"
 	testCases := []struct {

--- a/cuego/examples_test.go
+++ b/cuego/examples_test.go
@@ -41,7 +41,7 @@ func ExampleComplete_structTag() {
 	err = cuego.Complete(&a)
 	fmt.Println(errMsg(err))
 
-	//Output:
+	// Output:
 	// completed: cuego_test.Sum{A:1, B:5, C:6} (err: <nil>)
 	// completed: cuego_test.Sum{A:2, B:6, C:8} (err: <nil>)
 	// 2 errors in empty disjunction:
@@ -94,7 +94,7 @@ func ExampleConstrain() {
 
 	// TODO(errors): fix bound message (should be "does not match")
 
-	//Output:
+	// Output:
 	// error: nil
 	// validate: nil
 	// validate: 2 errors in empty disjunction:

--- a/doc/tutorial/kubernetes/tut_test.go
+++ b/doc/tutorial/kubernetes/tut_test.go
@@ -133,7 +133,7 @@ func TestTutorial(t *testing.T) {
 					r, err = os.OpenFile(
 						strings.TrimSpace(redirect[2:]),
 						os.O_APPEND|os.O_CREATE|os.O_WRONLY,
-						0666)
+						0o666)
 				} else { // strings.HasPrefix(redirect, ">")
 					// Create new file with input
 					r, err = os.Create(strings.TrimSpace(redirect[1:]))
@@ -182,7 +182,7 @@ func TestTutorial(t *testing.T) {
 					t.Fatal(err)
 				}
 				b = re.ReplaceAll(b, repl)
-				err = os.WriteFile(file, b, 0644)
+				err = os.WriteFile(file, b, 0o644)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -190,7 +190,7 @@ func TestTutorial(t *testing.T) {
 			case strings.HasPrefix(cmd, "touch "):
 				logf(t, "$ %s", cmd)
 				file := strings.TrimSpace(cmd[len("touch "):])
-				err := os.WriteFile(file, []byte(""), 0644)
+				err := os.WriteFile(file, []byte(""), 0o644)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -227,7 +227,7 @@ func TestTutorial(t *testing.T) {
 		err = filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
 			if isCUE(path) {
 				dst := path[len(dir)+1:]
-				err := os.MkdirAll(filepath.Dir(dst), 0755)
+				err := os.MkdirAll(filepath.Dir(dst), 0o755)
 				if err != nil {
 					return err
 				}
@@ -297,7 +297,7 @@ func TestEval(t *testing.T) {
 			testfile := filepath.Join("testdata", dir+".out")
 
 			if cuetest.UpdateGoldenFiles {
-				err := os.WriteFile(testfile, got, 0644)
+				err := os.WriteFile(testfile, got, 0o644)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/encoding/gocode/gen_test.go
+++ b/encoding/gocode/gen_test.go
@@ -32,7 +32,6 @@ type validator interface {
 }
 
 func TestPackages(t *testing.T) {
-
 	testCases := []struct {
 		name  string
 		value validator

--- a/encoding/gocode/gocodec/codec.go
+++ b/encoding/gocode/gocodec/codec.go
@@ -29,8 +29,7 @@ import (
 )
 
 // Config has no options yet, but is defined for future extensibility.
-type Config struct {
-}
+type Config struct{}
 
 // A Codec decodes and encodes CUE from and to Go values and validates and
 // completes Go values based on CUE templates.

--- a/encoding/gocode/gocodec/codec_test.go
+++ b/encoding/gocode/gocodec/codec_test.go
@@ -37,6 +37,7 @@ func checkErr(t *testing.T, got error, want string) {
 		t.Errorf("error: got %v; want %v", got, want)
 	}
 }
+
 func TestValidate(t *testing.T) {
 	fail := "some error"
 	testCases := []struct {

--- a/encoding/jsonschema/constraints.go
+++ b/encoding/jsonschema/constraints.go
@@ -149,7 +149,8 @@ var constraints = []*constraint{
 		// TODO: handle the case where this is always defined and we don't want
 		// to include the default value.
 		obj.Elts = append(obj.Elts, &ast.Attribute{
-			Text: fmt.Sprintf("@jsonschema(id=%q)", u)})
+			Text: fmt.Sprintf("@jsonschema(id=%q)", u),
+		})
 	}),
 
 	// Generic constraint
@@ -697,7 +698,6 @@ var constraints = []*constraint{
 		list := s.addImport(n, "list")
 		x := ast.NewCall(ast.NewSel(list, "MaxItems"), clearPos(s.uint(n)))
 		s.add(n, arrayType, x)
-
 	}),
 
 	p1("uniqueItems", func(n cue.Value, s *state) {

--- a/encoding/jsonschema/decode.go
+++ b/encoding/jsonschema/decode.go
@@ -121,7 +121,8 @@ func (d *decoder) schema(ref []ast.Label, v cue.Value) (a []ast.Decl) {
 		if len(tags) > 0 {
 			body := strings.Join(tags, ",")
 			a = append(a, &ast.Attribute{
-				Text: fmt.Sprintf("@jsonschema(%s)", body)})
+				Text: fmt.Sprintf("@jsonschema(%s)", body),
+			})
 		}
 
 		if state.deprecated {

--- a/encoding/jsonschema/decode_test.go
+++ b/encoding/jsonschema/decode_test.go
@@ -141,7 +141,7 @@ func TestDecode(t *testing.T) {
 
 			if updated {
 				b := txtar.Format(a)
-				err = os.WriteFile(fullpath, b, 0644)
+				err = os.WriteFile(fullpath, b, 0o644)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/encoding/jsonschema/ref.go
+++ b/encoding/jsonschema/ref.go
@@ -297,7 +297,6 @@ func (s *state) newSel(e ast.Expr, v cue.Value, a []string) ast.Expr {
 func newSel(e ast.Expr, label label) ast.Expr {
 	if label.isDef {
 		return ast.NewSel(e, label.name)
-
 	}
 	if ast.IsValidIdent(label.name) && !internal.IsDefOrHidden(label.name) {
 		return ast.NewSel(e, label.name)

--- a/encoding/openapi/build.go
+++ b/encoding/openapi/build.go
@@ -830,7 +830,6 @@ func (b *builder) object(v cue.Value) {
 //     schema: an array instance is valid if at least one element matches
 //     this schema.
 func (b *builder) array(v cue.Value) {
-
 	switch op, a := v.Expr(); op {
 	case cue.CallOp:
 		name := fmt.Sprint(a[0])
@@ -1265,7 +1264,7 @@ func (b *builder) addConjunct(f func(*builder)) {
 	b.add((*ast.StructLit)(c.finish()))
 }
 
-func (b *builder) addRef(v cue.Value, inst cue.Value, ref cue.Path) {
+func (b *builder) addRef(v, inst cue.Value, ref cue.Path) {
 	name := b.ctx.makeRef(inst, ref)
 	b.addConjunct(func(b *builder) {
 		b.allOf = append(b.allOf, ast.NewStruct(

--- a/encoding/openapi/decode_test.go
+++ b/encoding/openapi/decode_test.go
@@ -110,7 +110,7 @@ func TestDecode(t *testing.T) {
 					if cuetest.UpdateGoldenFiles {
 						a.Files[outIndex].Data = b
 						b = txtar.Format(a)
-						err = os.WriteFile(fullpath, b, 0644)
+						err = os.WriteFile(fullpath, b, 0o644)
 						if err != nil {
 							t.Fatal(err)
 						}

--- a/encoding/openapi/openapi.go
+++ b/encoding/openapi/openapi.go
@@ -137,7 +137,6 @@ func toCUE(name string, x interface{}) (v ast.Expr, err error) {
 			"openapi: could not encode %s", name)
 	}
 	return v, nil
-
 }
 
 func (c *Config) compose(inst cue.InstanceOrValue, schemas *ast.StructLit) (x *ast.StructLit, err error) {

--- a/encoding/openapi/openapi_test.go
+++ b/encoding/openapi/openapi_test.go
@@ -246,12 +246,12 @@ func TestParseDefinitions(t *testing.T) {
 					walk(all)
 				}
 
-				var out = &bytes.Buffer{}
+				out := &bytes.Buffer{}
 				_ = json.Indent(out, b, "", "   ")
 
 				wantFile := filepath.Join("testdata", tc.out)
 				if cuetest.UpdateGoldenFiles {
-					_ = os.WriteFile(wantFile, out.Bytes(), 0644)
+					_ = os.WriteFile(wantFile, out.Bytes(), 0o644)
 					return
 				}
 
@@ -343,7 +343,7 @@ func TestX(t *testing.T) {
 		t.Fatal(errors.Details(err, nil))
 	}
 
-	var out = &bytes.Buffer{}
+	out := &bytes.Buffer{}
 	_ = json.Indent(out, b, "", "   ")
 	t.Error(out.String())
 }

--- a/encoding/protobuf/examples_test.go
+++ b/encoding/protobuf/examples_test.go
@@ -26,14 +26,13 @@ import (
 
 func ExampleExtract() {
 	cwd, _ := os.Getwd()
-	var paths = []string{}
+	paths := []string{}
 	paths = append(paths, cwd)
 	paths = append(paths, filepath.Join(cwd, "testdata"))
 
 	f, err := protobuf.Extract("examples/basic/basic.proto", nil, &protobuf.Config{
 		Paths: paths,
 	})
-
 	if err != nil {
 		log.Fatal(err, "")
 	}

--- a/encoding/protobuf/parse.go
+++ b/encoding/protobuf/parse.go
@@ -381,7 +381,8 @@ func (p *protoConverter) stringLit(pos scanner.Position, s string) *ast.BasicLit
 	return &ast.BasicLit{
 		ValuePos: p.toCUEPos(pos),
 		Kind:     token.STRING,
-		Value:    literal.String.Quote(s)}
+		Value:    literal.String.Quote(s),
+	}
 }
 
 func (p *protoConverter) ident(pos scanner.Position, name string) *ast.Ident {
@@ -576,7 +577,6 @@ func (p *protoConverter) messageField(s *ast.StructLit, i int, v proto.Visitee) 
 // Enums are always defined at the top level. The name of a nested enum
 // will be prefixed with the name of its parent and an underscore.
 func (p *protoConverter) enum(x *proto.Enum) {
-
 	if len(x.Elements) == 0 {
 		failf(x.Position, "empty enum")
 	}
@@ -732,7 +732,6 @@ func (p *protoConverter) oneOf(x *proto.Oneof) {
 			newStruct()
 			p.messageField(s, 1, v)
 		}
-
 	}
 }
 
@@ -773,7 +772,6 @@ type optionParser struct {
 }
 
 func (p *optionParser) parse(options []*proto.Option) {
-
 	// TODO: handle options
 	// - translate options to tags
 	// - interpret CUE options.

--- a/encoding/protobuf/protobuf_test.go
+++ b/encoding/protobuf/protobuf_test.go
@@ -57,7 +57,7 @@ func TestExtractDefinitions(t *testing.T) {
 
 			wantFile := filepath.Join("testdata", filepath.Base(file)+".out.cue")
 			if cuetest.UpdateGoldenFiles {
-				_ = os.WriteFile(wantFile, out.Bytes(), 0644)
+				_ = os.WriteFile(wantFile, out.Bytes(), 0o644)
 				return
 			}
 
@@ -102,8 +102,8 @@ func TestBuild(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_ = os.MkdirAll(filepath.Dir(f.Filename), 0755)
-			err = os.WriteFile(f.Filename, b, 0644)
+			_ = os.MkdirAll(filepath.Dir(f.Filename), 0o755)
+			err = os.WriteFile(f.Filename, b, 0o644)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/encoding/protobuf/textproto/decoder.go
+++ b/encoding/protobuf/textproto/decoder.go
@@ -36,8 +36,7 @@ import (
 // There are currently no options.
 type Option func(*options)
 
-type options struct {
-}
+type options struct{}
 
 // NewDecoder returns a new Decoder
 func NewDecoder(option ...Option) *Decoder {
@@ -325,7 +324,6 @@ func (d *decoder) decodeMsg(m *mapping, n []*pbast.Node) ast.Expr {
 				label = ast.NewIdent(s)
 			} else {
 				label = ast.NewString(s)
-
 			}
 			// TODO: convert line number information. However, position
 			// information in textpbfmt packages is too wonky to be useful

--- a/encoding/protobuf/textproto/encoder_test.go
+++ b/encoding/protobuf/textproto/encoder_test.go
@@ -66,6 +66,5 @@ func TestEncode(t *testing.T) {
 			return
 		}
 		_, _ = t.Write(b)
-
 	})
 }

--- a/encoding/protobuf/util.go
+++ b/encoding/protobuf/util.go
@@ -40,9 +40,7 @@ type protoError struct {
 	error
 }
 
-var (
-	newSection = token.NewSection.Pos()
-)
+var newSection = token.NewSection.Pos()
 
 func addComments(f ast.Node, i int, doc, inline *proto.Comment) bool {
 	cg := comment(doc, true)

--- a/encoding/yaml/yaml_test.go
+++ b/encoding/yaml/yaml_test.go
@@ -241,7 +241,6 @@ func TestYAMLValues(t *testing.T) {
 			if got := strings.TrimSpace(string(b)); got != tc.yaml {
 				t.Errorf("Encode:\ngot  %q\nwant %q", got, tc.yaml)
 			}
-
 		})
 	}
 }

--- a/internal/astinternal/debugstr.go
+++ b/internal/astinternal/debugstr.go
@@ -196,7 +196,7 @@ func DebugStr(x interface{}) (out string) {
 			str += "l"
 		}
 		str += strconv.Itoa(int(v.Position))
-		var a = []string{}
+		a := []string{}
 		for _, c := range v.List {
 			a = append(a, c.Text)
 		}

--- a/internal/core/adt/composite.go
+++ b/internal/core/adt/composite.go
@@ -995,7 +995,6 @@ func (n *nodeContext) addConjunctDynamic(c Conjunct) {
 	n.node.Conjuncts = append(n.node.Conjuncts, c)
 	n.addExprConjunct(c, partial)
 	n.notifyConjunct(c)
-
 }
 
 func (n *nodeContext) notifyConjunct(c Conjunct) {

--- a/internal/core/adt/context.go
+++ b/internal/core/adt/context.go
@@ -527,7 +527,6 @@ func (c *OpContext) Validate(check Validator, value Value) *Bottom {
 // concrete returns the concrete value of x after evaluating it.
 // msg is used to mention the context in which an error occurred, if any.
 func (c *OpContext) concrete(env *Environment, x Expr, msg interface{}) (result Value, complete bool) {
-
 	w, complete := c.Evaluate(env, x)
 
 	w, ok := c.getDefault(w)
@@ -1167,7 +1166,6 @@ func (c *OpContext) ToBytes(v Value) []byte {
 // ToString returns the string value of a scalar value.
 func (c *OpContext) ToString(v Value) string {
 	return c.toStringValue(v, StringKind|NumKind|BytesKind|BoolKind, nil)
-
 }
 
 func (c *OpContext) stringValue(v Value, as interface{}) string {

--- a/internal/core/adt/decimal.go
+++ b/internal/core/adt/decimal.go
@@ -61,7 +61,6 @@ func numOp(c *OpContext, fn numFunc, x, y *Num) Value {
 	var d apd.Decimal
 
 	cond, err := fn(&d, &x.X, &y.X)
-
 	if err != nil {
 		return c.NewErrf("failed arithmetic: %v", err)
 	}

--- a/internal/core/adt/disjunct.go
+++ b/internal/core/adt/disjunct.go
@@ -98,7 +98,6 @@ type envDisjunct struct {
 }
 
 func (n *nodeContext) addDisjunction(env *Environment, x *DisjunctionExpr, cloneID CloseInfo) {
-
 	// TODO: precompute
 	numDefaults := 0
 	for _, v := range x.Values {
@@ -115,15 +114,14 @@ func (n *nodeContext) addDisjunction(env *Environment, x *DisjunctionExpr, clone
 func (n *nodeContext) addDisjunctionValue(env *Environment, x *Disjunction, cloneID CloseInfo) {
 	n.disjunctions = append(n.disjunctions,
 		envDisjunct{env, cloneID, nil, x, x.HasDefaults, false, false})
-
 }
 
 func (n *nodeContext) expandDisjuncts(
 	state vertexStatus,
 	parent *nodeContext,
 	parentMode defaultMode, // default mode of this disjunct
-	recursive, last bool) {
-
+	recursive, last bool,
+) {
 	n.ctx.stats.Disjuncts++
 
 	// refNode is used to collect cyclicReferences for all disjuncts to be
@@ -583,7 +581,6 @@ func selectErrors(a []*Bottom) (errs errors.Error) {
 	if len(a) <= 2 {
 		for _, b := range a {
 			errs = errors.Append(errs, b.Err)
-
 		}
 		return errs
 	}

--- a/internal/core/adt/eval.go
+++ b/internal/core/adt/eval.go
@@ -564,7 +564,6 @@ func (n *nodeContext) postDisjunct(state vertexStatus) {
 				if a.Label.Typ() == StringLabel && a.IsDefined(ctx) {
 					n.addErr(ctx.Newf("list may not have regular fields"))
 					// TODO(errors): add positions for list and arc definitions.
-
 				}
 			}
 
@@ -1228,8 +1227,8 @@ func (c *OpContext) freeNodeContext(n *nodeContext) {
 func (n *nodeContext) reportConflict(
 	v1, v2 Node,
 	k1, k2 Kind,
-	ids ...CloseInfo) {
-
+	ids ...CloseInfo,
+) {
 	ctx := n.ctx
 
 	var err *ValueError
@@ -1257,8 +1256,8 @@ func (n *nodeContext) reportFieldMismatch(
 	s *StructLit,
 	f Feature,
 	scalar Expr,
-	id ...CloseInfo) {
-
+	id ...CloseInfo,
+) {
 	ctx := n.ctx
 
 	if f == InvalidLabel {
@@ -1293,8 +1292,7 @@ func (n *nodeContext) updateNodeType(k Kind, v Expr, id CloseInfo) bool {
 	kind := n.kind & k
 
 	switch {
-	case n.kind == BottomKind,
-		k == BottomKind:
+	case n.kind == BottomKind, k == BottomKind:
 		return false
 
 	case kind != BottomKind:
@@ -1933,8 +1931,8 @@ func valueError(v Value) *ValueError {
 func (n *nodeContext) addStruct(
 	env *Environment,
 	s *StructLit,
-	closeInfo CloseInfo) {
-
+	closeInfo CloseInfo,
+) {
 	n.updateCyclicStatus(closeInfo)
 
 	// NOTE: This is a crucial point in the code:
@@ -2007,7 +2005,6 @@ func (n *nodeContext) addStruct(
 	}
 
 	parent.Disable = false
-
 }
 
 // TODO(perf): if an arc is the only arc with that label added to a Vertex, and

--- a/internal/core/adt/eval_test.go
+++ b/internal/core/adt/eval_test.go
@@ -34,9 +34,7 @@ import (
 	_ "cuelang.org/go/pkg"
 )
 
-var (
-	todo = flag.Bool("todo", false, "run tests marked with #todo-compile")
-)
+var todo = flag.Bool("todo", false, "run tests marked with #todo-compile")
 
 // TestEval tests the default implementation of the evaluator.
 func TestEval(t *testing.T) {

--- a/internal/core/adt/fields.go
+++ b/internal/core/adt/fields.go
@@ -355,7 +355,8 @@ func (n *nodeContext) insertArc1(f Feature, mode ArcType, c Conjunct, check bool
 //
 // If check is true it will not add c if it was already added.
 func (cc *closeContext) insertArc(
-	n *nodeContext, f Feature, mode ArcType, c Conjunct, check bool) (v *Vertex, isNew bool) {
+	n *nodeContext, f Feature, mode ArcType, c Conjunct, check bool,
+) (v *Vertex, isNew bool) {
 	c.CloseInfo.cc = nil
 
 	for _, a := range cc.Arcs {

--- a/internal/core/compile/compile.go
+++ b/internal/core/compile/compile.go
@@ -895,7 +895,8 @@ func (c *compiler) expr(expr ast.Expr) adt.Expr {
 		ret := &adt.SelectorExpr{
 			Src: n,
 			X:   c.expr(n.X),
-			Sel: c.label(n.Sel)}
+			Sel: c.label(n.Sel),
+		}
 		c.inSelector--
 		return ret
 

--- a/internal/core/compile/compile_test.go
+++ b/internal/core/compile/compile_test.go
@@ -28,9 +28,7 @@ import (
 	"cuelang.org/go/internal/cuetxtar"
 )
 
-var (
-	todo = flag.Bool("todo", false, "run tests marked with #todo-compile")
-)
+var todo = flag.Bool("todo", false, "run tests marked with #todo-compile")
 
 func TestCompile(t *testing.T) {
 	test := cuetxtar.TxTarTest{

--- a/internal/core/convert/go.go
+++ b/internal/core/convert/go.go
@@ -93,7 +93,7 @@ func parseTag(ctx *adt.OpContext, obj *ast.StructLit, field, tag string) ast.Exp
 }
 
 // splitTag splits a cue tag into cue and options.
-func splitTag(tag string) (cue string, options string) {
+func splitTag(tag string) (cue, options string) {
 	q := strings.LastIndexByte(tag, '"')
 	if c := strings.IndexByte(tag[q+1:], ','); c >= 0 {
 		return tag[:q+1+c], tag[q+1+c+1:]

--- a/internal/core/convert/go_test.go
+++ b/internal/core/convert/go_test.go
@@ -57,81 +57,111 @@ func TestConvert(t *testing.T) {
 	testCases := []struct {
 		goVal interface{}
 		want  string
-	}{{
-		nil, "(_){ _ }",
-	}, {
-		true, "(bool){ true }",
-	}, {
-		false, "(bool){ false }",
-	}, {
-		errors.New("oh noes"), "(_|_){\n  // [eval] oh noes\n}",
-	}, {
-		"foo", `(string){ "foo" }`,
-	}, {
-		"\x80", `(string){ "�" }`,
-	}, {
-		3, "(int){ 3 }",
-	}, {
-		uint(3), "(int){ 3 }",
-	}, {
-		uint8(3), "(int){ 3 }",
-	}, {
-		uint16(3), "(int){ 3 }",
-	}, {
-		uint32(3), "(int){ 3 }",
-	}, {
-		uint64(3), "(int){ 3 }",
-	}, {
-		int8(-3), "(int){ -3 }",
-	}, {
-		int16(-3), "(int){ -3 }",
-	}, {
-		int32(-3), "(int){ -3 }",
-	}, {
-		int64(-3), "(int){ -3 }",
-	}, {
-		float64(3), "(float){ 3 }",
-	}, {
-		float64(3.1), "(float){ 3.1 }",
-	}, {
-		float32(3.1), "(float){ 3.1 }",
-	}, {
-		uintptr(3), "(int){ 3 }",
-	}, {
-		&i34, "(int){ 34 }",
-	}, {
-		&f37, "(float){ 37 }",
-	}, {
-		&d35, "(int){ 35 }",
-	}, {
-		&n36, "(int){ -36 }",
-	}, {
-		[]int{1, 2, 3, 4}, `(#list){
+	}{
+		{
+			nil, "(_){ _ }",
+		},
+		{
+			true, "(bool){ true }",
+		},
+		{
+			false, "(bool){ false }",
+		},
+		{
+			errors.New("oh noes"), "(_|_){\n  // [eval] oh noes\n}",
+		},
+		{
+			"foo", `(string){ "foo" }`,
+		},
+		{
+			"\x80", `(string){ "�" }`,
+		},
+		{
+			3, "(int){ 3 }",
+		},
+		{
+			uint(3), "(int){ 3 }",
+		},
+		{
+			uint8(3), "(int){ 3 }",
+		},
+		{
+			uint16(3), "(int){ 3 }",
+		},
+		{
+			uint32(3), "(int){ 3 }",
+		},
+		{
+			uint64(3), "(int){ 3 }",
+		},
+		{
+			int8(-3), "(int){ -3 }",
+		},
+		{
+			int16(-3), "(int){ -3 }",
+		},
+		{
+			int32(-3), "(int){ -3 }",
+		},
+		{
+			int64(-3), "(int){ -3 }",
+		},
+		{
+			float64(3), "(float){ 3 }",
+		},
+		{
+			float64(3.1), "(float){ 3.1 }",
+		},
+		{
+			float32(3.1), "(float){ 3.1 }",
+		},
+		{
+			uintptr(3), "(int){ 3 }",
+		},
+		{
+			&i34, "(int){ 34 }",
+		},
+		{
+			&f37, "(float){ 37 }",
+		},
+		{
+			&d35, "(int){ 35 }",
+		},
+		{
+			&n36, "(int){ -36 }",
+		},
+		{
+			[]int{1, 2, 3, 4}, `(#list){
   0: (int){ 1 }
   1: (int){ 2 }
   2: (int){ 3 }
   3: (int){ 4 }
 }`,
-	}, {
-		struct {
-			A int
-			B *int
-		}{3, nil},
-		"(struct){\n  A: (int){ 3 }\n}",
-	}, {
-		[]interface{}{}, "(#list){\n}",
-	}, {
-		[]interface{}{nil}, "(#list){\n  0: (_){ _ }\n}",
-	}, {
-		map[string]interface{}{"a": 1, "x": nil}, `(struct){
+		},
+		{
+			struct {
+				A int
+				B *int
+			}{3, nil},
+			"(struct){\n  A: (int){ 3 }\n}",
+		},
+		{
+			[]interface{}{}, "(#list){\n}",
+		},
+		{
+			[]interface{}{nil}, "(#list){\n  0: (_){ _ }\n}",
+		},
+		{
+			map[string]interface{}{"a": 1, "x": nil}, `(struct){
   a: (int){ 1 }
   x: (_){ _ }
 }`,
-	}, {
-		map[string][]int{
-			"a": {1},
-			"b": {3, 4},
-		}, `(struct){
+		},
+		{
+			map[string][]int{
+				"a": {1},
+				"b": {3, 4},
+			}, `(struct){
   a: (#list){
     0: (int){ 1 }
   }
@@ -140,94 +170,119 @@ func TestConvert(t *testing.T) {
     1: (int){ 4 }
   }
 }`,
-	}, {
-		map[bool]int{}, "(_|_){\n  // [eval] unsupported Go type for map key (bool)\n}",
-	}, {
-		map[struct{}]int{{}: 2}, "(_|_){\n  // [eval] unsupported Go type for map key (struct {})\n}",
-	}, {
-		map[int]int{1: 2}, `(struct){
+		},
+		{
+			map[bool]int{}, "(_|_){\n  // [eval] unsupported Go type for map key (bool)\n}",
+		},
+		{
+			map[struct{}]int{{}: 2}, "(_|_){\n  // [eval] unsupported Go type for map key (struct {})\n}",
+		},
+		{
+			map[int]int{1: 2}, `(struct){
   "1": (int){ 2 }
 }`,
-	}, {
-		struct {
-			a int
-			b int
-		}{3, 4},
-		"(struct){\n}",
-	}, {
-		struct {
-			A int
-			B int `json:"-"`
-			C int `json:",omitempty"`
-		}{3, 4, 0},
-		`(struct){
+		},
+		{
+			struct {
+				a int
+				b int
+			}{3, 4},
+			"(struct){\n}",
+		},
+		{
+			struct {
+				A int
+				B int `json:"-"`
+				C int `json:",omitempty"`
+			}{3, 4, 0},
+			`(struct){
   A: (int){ 3 }
 }`,
-	}, {
-		struct {
-			A int
-			B int
-		}{3, 4},
-		`(struct){
+		},
+		{
+			struct {
+				A int
+				B int
+			}{3, 4},
+			`(struct){
   A: (int){ 3 }
   B: (int){ 4 }
 }`,
-	}, {
-		struct {
-			A int `json:"a"`
-			B int `yaml:"b"`
-		}{3, 4},
-		`(struct){
+		},
+		{
+			struct {
+				A int `json:"a"`
+				B int `yaml:"b"`
+			}{3, 4},
+			`(struct){
   a: (int){ 3 }
   b: (int){ 4 }
 }`,
-	}, {
-		struct {
-			A int `json:"" yaml:"" protobuf:"aa"`
-			B int `yaml:"cc" json:"bb" protobuf:"aa"`
-		}{3, 4},
-		`(struct){
+		},
+		{
+			struct {
+				A int `json:"" yaml:"" protobuf:"aa"`
+				B int `yaml:"cc" json:"bb" protobuf:"aa"`
+			}{3, 4},
+			`(struct){
   aa: (int){ 3 }
   bb: (int){ 4 }
 }`,
-	}, {
-		&struct{ A int }{3}, `(struct){
+		},
+		{
+			&struct{ A int }{3}, `(struct){
   A: (int){ 3 }
 }`,
-	}, {
-		(*struct{ A int })(nil), "(_){ _ }",
-	}, {
-		reflect.ValueOf(3), "(int){ 3 }",
-	}, {
-		time.Date(2019, 4, 1, 0, 0, 0, 0, time.UTC), `(string){ "2019-04-01T00:00:00Z" }`,
-	}, {
-		func() interface{} {
-			type T struct {
-				B int
-			}
-			type S struct {
-				A string
-				T
-			}
-			return S{}
-		}(),
-		`(struct){
+		},
+		{
+			(*struct{ A int })(nil), "(_){ _ }",
+		},
+		{
+			reflect.ValueOf(3), "(int){ 3 }",
+		},
+		{
+			time.Date(2019, 4, 1, 0, 0, 0, 0, time.UTC), `(string){ "2019-04-01T00:00:00Z" }`,
+		},
+		{
+			func() interface{} {
+				type T struct {
+					B int
+				}
+				type S struct {
+					A string
+					T
+				}
+				return S{}
+			}(),
+			`(struct){
   A: (string){ "" }
   B: (int){ 0 }
 }`,
-	},
-		{map[key]string{{a: 1}: "foo"},
-			"(_|_){\n  // [eval] unsupported Go type for map key (convert_test.key)\n}"},
-		{map[*textMarshaller]string{{b: "bar"}: "foo"},
-			"(struct){\n  \"&{bar}\": (string){ \"foo\" }\n}"},
-		{map[int]string{1: "foo"},
-			"(struct){\n  \"1\": (string){ \"foo\" }\n}"},
-		{map[string]encoding.TextMarshaler{"foo": nil},
-			"(struct){\n  foo: (_){ _ }\n}"},
-		{make(chan int),
-			"(_|_){\n  // [eval] unsupported Go type (chan int)\n}"},
-		{[]interface{}{func() {}},
-			"(_|_){\n  // [eval] unsupported Go type (func())\n}"},
+		},
+		{
+			map[key]string{{a: 1}: "foo"},
+			"(_|_){\n  // [eval] unsupported Go type for map key (convert_test.key)\n}",
+		},
+		{
+			map[*textMarshaller]string{{b: "bar"}: "foo"},
+			"(struct){\n  \"&{bar}\": (string){ \"foo\" }\n}",
+		},
+		{
+			map[int]string{1: "foo"},
+			"(struct){\n  \"1\": (string){ \"foo\" }\n}",
+		},
+		{
+			map[string]encoding.TextMarshaler{"foo": nil},
+			"(struct){\n  foo: (_){ _ }\n}",
+		},
+		{
+			make(chan int),
+			"(_|_){\n  // [eval] unsupported Go type (chan int)\n}",
+		},
+		{
+			[]interface{}{func() {}},
+			"(_|_){\n  // [eval] unsupported Go type (func())\n}",
+		},
 		{stringType("\x80"), `(string){ "�" }`},
 	}
 	r := runtime.New()

--- a/internal/core/export/adt.go
+++ b/internal/core/export/adt.go
@@ -421,7 +421,8 @@ func (e *exporter) resolve(env *adt.Environment, r adt.Resolver) ast.Expr {
 func (e *exporter) newIdentForField(
 	orig *ast.Ident,
 	label adt.Feature,
-	upCount int32) (ident *ast.Ident, ok bool) {
+	upCount int32,
+) (ident *ast.Ident, ok bool) {
 	f := e.frame(upCount)
 	entry := f.fields[label]
 
@@ -614,7 +615,6 @@ func aliasFromLabel(src *ast.Field) string {
 }
 
 func (e *exporter) elem(env *adt.Environment, d adt.Elem) ast.Expr {
-
 	switch x := d.(type) {
 	case adt.Expr:
 		return e.expr(env, x)

--- a/internal/core/export/bounds.go
+++ b/internal/core/export/bounds.go
@@ -114,7 +114,6 @@ func (s *boundSimplifier) expr(ctx *adt.OpContext) (e ast.Expr) {
 		}
 		if sign := s.minNum.X.Sign(); sign == -1 {
 			e = ast.NewIdent("int")
-
 		} else {
 			e = ast.NewIdent("uint")
 			if sign == 0 && s.min.Op == adt.GreaterEqualOp {
@@ -178,8 +177,10 @@ var intRanges = []builtinRange{
 	{"int16", makeDec("-32768"), makeDec("32767")},
 	{"int32", makeDec("-2147483648"), makeDec("2147483647")},
 	{"int64", makeDec("-9223372036854775808"), makeDec("9223372036854775807")},
-	{"int128", makeDec("-170141183460469231731687303715884105728"),
-		makeDec("170141183460469231731687303715884105727")},
+	{
+		"int128", makeDec("-170141183460469231731687303715884105728"),
+		makeDec("170141183460469231731687303715884105727"),
+	},
 
 	{"uint8", makeDec("0"), makeDec("255")},
 	{"uint16", makeDec("0"), makeDec("65535")},
@@ -192,14 +193,18 @@ var intRanges = []builtinRange{
 
 var floatRanges = []builtinRange{
 	// 2**127 * (2**24 - 1) / 2**23
-	{"float32",
+	{
+		"float32",
 		makeDec("-3.40282346638528859811704183484516925440e+38"),
-		makeDec("3.40282346638528859811704183484516925440e+38")},
+		makeDec("3.40282346638528859811704183484516925440e+38"),
+	},
 
 	// 2**1023 * (2**53 - 1) / 2**52
-	{"float64",
+	{
+		"float64",
 		makeDec("-1.797693134862315708145274237317043567981e+308"),
-		makeDec("1.797693134862315708145274237317043567981e+308")},
+		makeDec("1.797693134862315708145274237317043567981e+308"),
+	},
 }
 
 func wrapBin(a, b ast.Expr, op adt.Op) ast.Expr {

--- a/internal/core/export/export_test.go
+++ b/internal/core/export/export_test.go
@@ -352,7 +352,6 @@ func TestFromAPI(t *testing.T) {
 
 			r, x := value.ToInternal(v)
 			file, err := export.Def(r, "foo", x)
-
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -361,7 +360,6 @@ func TestFromAPI(t *testing.T) {
 			if got != tc.out {
 				t.Errorf("got:  %s\nwant: %s", got, tc.out)
 			}
-
 		})
 	}
 }

--- a/internal/core/export/expr.go
+++ b/internal/core/export/expr.go
@@ -106,7 +106,6 @@ func (e *exporter) expr(env *adt.Environment, v adt.Elem) (result ast.Expr) {
 // unified. All other conjuncts are added verbatim.
 
 func (x *exporter) mergeValues(label adt.Feature, src *adt.Vertex, a []conjunct, orig ...adt.Conjunct) (expr ast.Expr) {
-
 	e := conjuncts{
 		exporter: x,
 		values:   &adt.Vertex{},

--- a/internal/core/runtime/extern.go
+++ b/internal/core/runtime/extern.go
@@ -164,7 +164,6 @@ loop:
 			if kind != "" {
 				return "", pos, nil, errors.Newf(a.Pos(),
 					"only one file-level extern attribute allowed per file")
-
 			}
 			kind = k
 		}
@@ -278,7 +277,6 @@ func (d *externDecorator) markExternFieldAttr(kind string, decls []ast.Decl) (er
 		}
 
 		return true
-
 	}, func(n ast.Node) {
 		switch n.(type) {
 		case *ast.Field:

--- a/internal/core/runtime/resolve_test.go
+++ b/internal/core/runtime/resolve_test.go
@@ -54,7 +54,6 @@ func TestPartiallyResolved(t *testing.T) {
 			PkgName:    "foo",
 		}},
 	}, map[string]ast.Node{})
-
 	if err != nil {
 		t.Errorf("exected no error, found %v", err)
 	}

--- a/internal/core/subsume/structural.go
+++ b/internal/core/subsume/structural.go
@@ -177,8 +177,8 @@ func (s *subsumer) structural(a, b adt.Conjunct) bool {
 
 func (s *subsumer) structLit(
 	ea *adt.Environment, sa *adt.StructLit,
-	eb *adt.Environment, sb *adt.StructLit) bool {
-
+	eb *adt.Environment, sb *adt.StructLit,
+) bool {
 	// Create index of instance fields.
 	ca := newCollatedDecls()
 	ca.collate(ea, sa)
@@ -213,11 +213,9 @@ func (s *subsumer) structLit(
 		// 		return false
 		// 	}
 		// }
-
 	}
 
 	return false
-
 }
 
 // collatedDecls is used to compute the structural subsumption of two

--- a/internal/core/subsume/structural_test.go
+++ b/internal/core/subsume/structural_test.go
@@ -184,27 +184,32 @@ func TestStructural(t *testing.T) {
 		104: {subsumes: true, in: `a: !bool, b: !bool`},
 
 		// Call
-		113: {subsumes: true, in: `
+		113: {
+			subsumes: true, in: `
 			a: fn()
 			b: fn()
 			fn: _`,
 		},
-		114: {subsumes: false, in: `
+		114: {
+			subsumes: false, in: `
 			a: fn(),
 			b: fn(1)
 			fn: _`,
 		},
-		115: {subsumes: true, in: `
+		115: {
+			subsumes: true, in: `
 			a: fn(2)
 			b: fn(2)
 			fn: _`,
 		},
-		116: {subsumes: true, in: `
+		116: {
+			subsumes: true, in: `
 			a: fn(number)
 			b: fn(2)
 			fn: _`,
 		},
-		117: {subsumes: false, in: `
+		117: {
+			subsumes: false, in: `
 			a: fn(2)
 			b: fn(number)
 			fn: _`,
@@ -459,7 +464,6 @@ func TestStructural(t *testing.T) {
 		r := runtime.New()
 
 		t.Run(strconv.Itoa(i)+"/"+key, func(t *testing.T) {
-
 			file, err := parser.ParseFile("subsume", tc.in)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/core/subsume/value_test.go
+++ b/internal/core/subsume/value_test.go
@@ -428,7 +428,6 @@ func TestValues(t *testing.T) {
 		r := runtime.New()
 
 		t.Run(strconv.Itoa(i)+"/"+key, func(t *testing.T) {
-
 			file, err := parser.ParseFile("subsume", tc.in)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/cuetest/cuetest.go
+++ b/internal/cuetest/cuetest.go
@@ -39,18 +39,16 @@ const (
 	envFormatTxtar = "CUE_FORMAT_TXTAR"
 )
 
-var (
-	// issuesConditions is a set of regular expressions that defines the set of
-	// conditions that can be used to declare links to issues in various issue
-	// trackers. e.g. in testscript condition form
-	//
-	//     [golang.org/issues/1234]
-	//     [github.com/govim/govim/issues/4321]
-	issuesConditions = []*regexp.Regexp{
-		regexp.MustCompile(`^golang\.org/issues?/\d+$`),
-		regexp.MustCompile(`^cuelang\.org/issues?/\d+$`),
-	}
-)
+// issuesConditions is a set of regular expressions that defines the set of
+// conditions that can be used to declare links to issues in various issue
+// trackers. e.g. in testscript condition form
+//
+//     [golang.org/issues/1234]
+//     [github.com/govim/govim/issues/4321]
+var issuesConditions = []*regexp.Regexp{
+	regexp.MustCompile(`^golang\.org/issues?/\d+$`),
+	regexp.MustCompile(`^cuelang\.org/issues?/\d+$`),
+}
 
 // UpdateGoldenFiles determines whether testscript scripts should update txtar
 // archives in the event of cmp failures.
@@ -118,7 +116,7 @@ func IssueSkip(t *testing.T, s string) {
 // CUE_NON_ISSUES for a match, in which case nonIssue is true (a value of true
 // indicates roughly that we don't believe issue s is an issue any more). In
 // case of any errors err is set.
-func checkIssueCondition(s string) (isIssue bool, nonIssue bool, err error) {
+func checkIssueCondition(s string) (isIssue, nonIssue bool, err error) {
 	var r *regexp.Regexp
 	if v := os.Getenv(envNonIssues); v != "" {
 		r, err = regexp.Compile(v)

--- a/internal/cuetest/cuetest_test.go
+++ b/internal/cuetest/cuetest_test.go
@@ -98,5 +98,4 @@ func TestCheckIssueCondition(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/internal/cuetxtar/txtar.go
+++ b/internal/cuetxtar/txtar.go
@@ -449,7 +449,7 @@ func (x *TxTarTest) Run(t *testing.T, f func(tc *Test)) {
 			a.Files = files
 
 			if update {
-				err = os.WriteFile(fullpath, txtar.Format(a), 0644)
+				err = os.WriteFile(fullpath, txtar.Format(a), 0o644)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -61,8 +61,10 @@ type Decoder struct {
 	err            error
 }
 
-type interpretFunc func(*cue.Instance) (file *ast.File, id string, err error)
-type rewriteFunc func(*ast.File) (file *ast.File, err error)
+type (
+	interpretFunc func(*cue.Instance) (file *ast.File, id string, err error)
+	rewriteFunc   func(*ast.File) (file *ast.File, err error)
+)
 
 // ID returns a canonical identifier for the decoded object or "" if no such
 // identifier could be found.

--- a/internal/encoding/encoding_test.go
+++ b/internal/encoding/encoding_test.go
@@ -29,24 +29,26 @@ func TestValidate(t *testing.T) {
 		in     string
 		err    string
 		compat bool
-	}{{
-		form: "data",
-		in: `
+	}{
+		{
+			form: "data",
+			in: `
 		// Foo
 		a: 2
 		"b-b": 3
 		s: -2
 		a: +2
 		`,
-	}, {
-		form: "graph",
-		in: `
+		},
+		{
+			form: "graph",
+			in: `
 		let X = 3
 		a: X
 		"b-b": 3
 		s: a
 		`,
-	},
+		},
 
 		{form: "data", err: "imports", in: `import "foo" `},
 		{form: "data", err: "references", in: `a: a`},

--- a/internal/encoding/json/encode.go
+++ b/internal/encoding/json/encode.go
@@ -131,6 +131,7 @@ func (e *encoder) ws(pos token.Pos, default_ token.RelPos) {
 		e.indent()
 	}
 }
+
 func (e *encoder) encode(n ast.Node) error {
 	if e.tab == nil {
 		e.tab = []byte("    ")

--- a/internal/filetypes/gen.go
+++ b/internal/filetypes/gen.go
@@ -45,7 +45,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if err := os.WriteFile("types.go", b, 0644); err != nil {
+	if err := os.WriteFile("types.go", b, 0o644); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/internal/mod/modfile/modfile.go
+++ b/internal/mod/modfile/modfile.go
@@ -62,7 +62,7 @@ func moduleSchema() cue.Value {
 		ctx := cuecontext.New()
 		schemav := ctx.CompileBytes(moduleSchemaData, cue.Filename("cuelang.org/go/internal/mod/modfile/schema.cue"))
 		schemav = lookup(schemav, cue.Def("#File"))
-		//schemav = schemav.Unify(lookup(schemav, cue.Hid("#Strict", "_")))
+		// schemav = schemav.Unify(lookup(schemav, cue.Hid("#Strict", "_")))
 		if err := schemav.Validate(); err != nil {
 			panic(fmt.Errorf("internal error: invalid CUE module.cue schema: %v", errors.Details(err, nil)))
 		}

--- a/internal/mod/modregistry/client.go
+++ b/internal/mod/modregistry/client.go
@@ -344,7 +344,7 @@ func isJSON(mediaType string) bool {
 // scratchConfig returns a dummy configuration consisting only of the
 // two-byte configuration {}.
 // https://github.com/opencontainers/image-spec/blob/main/manifest.md#example-of-a-scratch-config-or-layer-descriptor
-func (c *Client) scratchConfig(ctx context.Context, repoName string, mediaType string) (ocispec.Descriptor, error) {
+func (c *Client) scratchConfig(ctx context.Context, repoName, mediaType string) (ocispec.Descriptor, error) {
 	// TODO check if it exists already to avoid push?
 	content := []byte("{}")
 	desc := ocispec.Descriptor{

--- a/internal/mod/module/module.go
+++ b/internal/mod/module/module.go
@@ -98,7 +98,7 @@ func ParseVersion(s string) (Version, error) {
 	return Version{basePath + "@" + semver.Major(vers), vers}, nil
 }
 
-func MustNewVersion(path string, vers string) Version {
+func MustNewVersion(path, vers string) Version {
 	v, err := NewVersion(path, vers)
 	if err != nil {
 		panic(err)
@@ -110,7 +110,7 @@ func MustNewVersion(path string, vers string) Version {
 // The version must be canonical, empty or "none".
 // If the path doesn't have a major version suffix, one will be added
 // if the version isn't empty; if the version is empty, it's an error.
-func NewVersion(path string, vers string) (Version, error) {
+func NewVersion(path, vers string) (Version, error) {
 	if vers != "" && vers != "none" {
 		if !semver.IsValid(vers) {
 			return Version{}, fmt.Errorf("version %q (of module %q) is not well formed", vers, path)

--- a/internal/mod/mvs/graph.go
+++ b/internal/mod/mvs/graph.go
@@ -167,7 +167,7 @@ func (g *Graph[V]) sortVersions(vs []V) {
 	})
 }
 
-func (g *Graph[V]) newVersion(path string, vers string) V {
+func (g *Graph[V]) newVersion(path, vers string) V {
 	v, err := g.v.New(path, vers)
 	if err != nil {
 		// Note: can't happen because all paths and versions passed to

--- a/internal/mod/mvs/mvs.go
+++ b/internal/mod/mvs/mvs.go
@@ -115,7 +115,6 @@ func buildList[V comparable](targets []V, reqs Reqs[V], upgrade func(V) (V, erro
 		work.Add(target)
 	}
 	work.Do(10, func(m V) {
-
 		var required []V
 		var err error
 		if reqs.Version(m) != "none" {

--- a/internal/mod/zip/zip.go
+++ b/internal/mod/zip/zip.go
@@ -644,7 +644,7 @@ func Unzip(dir string, m module.Version, zipFile string) (err error) {
 	}
 
 	// Unzip, enforcing sizes declared in the zip file.
-	if err := os.MkdirAll(dir, 0777); err != nil {
+	if err := os.MkdirAll(dir, 0o777); err != nil {
 		return err
 	}
 	for _, zf := range z.File {
@@ -653,10 +653,10 @@ func Unzip(dir string, m module.Version, zipFile string) (err error) {
 			continue
 		}
 		dst := filepath.Join(dir, name)
-		if err := os.MkdirAll(filepath.Dir(dst), 0777); err != nil {
+		if err := os.MkdirAll(filepath.Dir(dst), 0o777); err != nil {
 			return err
 		}
-		w, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0444)
+		w, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o444)
 		if err != nil {
 			return err
 		}
@@ -873,9 +873,11 @@ type ZipFileIO struct {
 func (fio ZipFileIO) Path(f *zip.File) string {
 	return strings.TrimPrefix(f.Name, fio.StripPrefix)
 }
+
 func (ZipFileIO) Lstat(f *zip.File) (os.FileInfo, error) {
 	return f.FileInfo(), nil
 }
+
 func (ZipFileIO) Open(f *zip.File) (io.ReadCloser, error) {
 	return f.Open()
 }

--- a/internal/mod/zip/zip_test.go
+++ b/internal/mod/zip/zip_test.go
@@ -91,10 +91,10 @@ func extractTxtarToTempDir(t testing.TB, arc *txtar.Archive) (dir string, err er
 	dir = t.TempDir()
 	for _, f := range arc.Files {
 		filePath := filepath.Join(dir, f.Name)
-		if err := os.MkdirAll(filepath.Dir(filePath), 0777); err != nil {
+		if err := os.MkdirAll(filepath.Dir(filePath), 0o777); err != nil {
 			return "", err
 		}
-		if err := os.WriteFile(filePath, f.Data, 0666); err != nil {
+		if err := os.WriteFile(filePath, f.Data, 0o666); err != nil {
 			return "", err
 		}
 	}
@@ -165,6 +165,7 @@ func (fi fakeFileInfo) Size() int64 {
 	}
 	return int64(fi.f.size)
 }
+
 func (fi fakeFileInfo) Mode() os.FileMode {
 	if fi.f.isDir {
 		return os.ModeDir | 0o755
@@ -530,7 +531,7 @@ func TestCreateFromDirSpecial(t *testing.T) {
 		{
 			desc: "ignore_empty_dir",
 			setup: func(t *testing.T, tmpDir string) string {
-				if err := os.Mkdir(filepath.Join(tmpDir, "empty"), 0777); err != nil {
+				if err := os.Mkdir(filepath.Join(tmpDir, "empty"), 0o777); err != nil {
 					t.Fatal(err)
 				}
 				mustWriteFile(
@@ -562,7 +563,7 @@ func TestCreateFromDirSpecial(t *testing.T) {
 			desc: "dir_is_vendor",
 			setup: func(t *testing.T, tmpDir string) string {
 				vendorDir := filepath.Join(tmpDir, "vendor")
-				if err := os.Mkdir(vendorDir, 0777); err != nil {
+				if err := os.Mkdir(vendorDir, 0o777); err != nil {
 					t.Fatal(err)
 				}
 				mustWriteFile(
@@ -956,7 +957,7 @@ func TestUnzipSizeLimitsSpecial(t *testing.T) {
 	}
 }
 
-func mustWriteFile(name string, content string) {
+func mustWriteFile(name, content string) {
 	if err := os.MkdirAll(filepath.Dir(name), 0o777); err != nil {
 		panic(err)
 	}

--- a/internal/pkg/builtin.go
+++ b/internal/pkg/builtin.go
@@ -180,7 +180,6 @@ func mustParseConstBuiltin(ctx adt.Runtime, name, val string) adt.Expr {
 		panic(err)
 	}
 	return c.Expr()
-
 }
 
 func (x *Builtin) name(ctx *adt.OpContext) string {

--- a/internal/registrytest/txtar_fs.go
+++ b/internal/registrytest/txtar_fs.go
@@ -114,7 +114,7 @@ type openFile struct {
 func newOpenFile(f txtar.File) *openFile {
 	var o openFile
 	o.Reader.Reset(f.Data)
-	o.fi = fileInfo{f, 0444}
+	o.fi = fileInfo{f, 0o444}
 	return &o
 }
 
@@ -130,11 +130,11 @@ type fileInfo struct {
 }
 
 func newFileInfo(f txtar.File) fileInfo {
-	return fileInfo{f, 0444}
+	return fileInfo{f, 0o444}
 }
 
 func newDirInfo(name string) fileInfo {
-	return fileInfo{txtar.File{Name: name}, fs.ModeDir | 0555}
+	return fileInfo{txtar.File{Name: name}, fs.ModeDir | 0o555}
 }
 
 func (f fileInfo) Name() string               { return path.Base(f.f.Name) }

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -80,7 +80,6 @@ func (c *Context) Bytes(field string) []byte {
 }
 
 func (c *Context) addErr(v cue.Value, wrap error, format string, args ...interface{}) {
-
 	err := &taskError{
 		task:    c.Obj,
 		v:       v,

--- a/internal/tdtest/update.go
+++ b/internal/tdtest/update.go
@@ -362,13 +362,17 @@ func (t *T) updateField(info *info, ci *callInfo, newValue any) {
 		}
 	case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int8:
 		i := x.Int()
-		value = &ast.BasicLit{Kind: token.INT,
-			Value: strconv.FormatInt(i, 10)}
+		value = &ast.BasicLit{
+			Kind:  token.INT,
+			Value: strconv.FormatInt(i, 10),
+		}
 		isZero = i == 0
 	case reflect.Uint, reflect.Uint64, reflect.Uint32, reflect.Uint8:
 		i := x.Uint()
-		value = &ast.BasicLit{Kind: token.INT,
-			Value: strconv.FormatUint(i, 10)}
+		value = &ast.BasicLit{
+			Kind:  token.INT,
+			Value: strconv.FormatUint(i, 10),
+		}
 		isZero = i == 0
 	}
 

--- a/internal/third_party/yaml/apic.go
+++ b/internal/third_party/yaml/apic.go
@@ -5,7 +5,7 @@ import (
 )
 
 func yaml_insert_token(parser *yaml_parser_t, pos int, token *yaml_token_t) {
-	//fmt.Println("yaml_insert_token", "pos:", pos, "typ:", token.typ, "head:", parser.tokens_head, "len:", len(parser.tokens))
+	// fmt.Println("yaml_insert_token", "pos:", pos, "typ:", token.typ, "head:", parser.tokens_head, "len:", len(parser.tokens))
 
 	// Check if we can move the queue at the beginning of the buffer.
 	if parser.tokens_head > 0 && len(parser.tokens) == cap(parser.tokens) {

--- a/internal/third_party/yaml/decode_test.go
+++ b/internal/third_party/yaml/decode_test.go
@@ -28,43 +28,56 @@ var unmarshalTests = []struct {
 	{
 		"{}",
 		"",
-	}, {
+	},
+	{
 		"v: hi",
 		`v: "hi"`,
-	}, {
+	},
+	{
 		"v: hi",
 		`v: "hi"`,
-	}, {
+	},
+	{
 		"v: true",
 		"v: true",
-	}, {
+	},
+	{
 		"v: 10",
 		"v: 10",
-	}, {
+	},
+	{
 		"v: 0b10",
 		"v: 0b10",
-	}, {
+	},
+	{
 		"v: 0xA",
 		"v: 0xA",
-	}, {
+	},
+	{
 		"v: 4294967296",
 		"v: 4294967296",
-	}, {
+	},
+	{
 		"v: 0.1",
 		"v: 0.1",
-	}, {
+	},
+	{
 		"v: .1",
 		"v: 0.1",
-	}, {
+	},
+	{
 		"v: .Inf",
 		"v: +Inf",
-	}, {
+	},
+	{
 		"v: -.Inf",
 		"v: -Inf",
-	}, {
+	},
+	{
 		"v: -10",
 		"v: -10",
-	}, {
+	},
+	{
 		"v: -.1",
 		"v: -0.1",
 	},
@@ -79,16 +92,20 @@ var unmarshalTests = []struct {
 	{
 		"canonical: 6.8523e+5",
 		"canonical: 6.8523e+5",
-	}, {
+	},
+	{
 		"expo: 685.230_15e+03",
 		"expo: 685.230_15e+03",
-	}, {
+	},
+	{
 		"fixed: 685_230.15",
 		"fixed: 685_230.15",
-	}, {
+	},
+	{
 		"neginf: -.inf",
 		"neginf: -Inf",
-	}, {
+	},
+	{
 		"fixed: 685_230.15",
 		"fixed: 685_230.15",
 	},
@@ -99,19 +116,24 @@ var unmarshalTests = []struct {
 	{
 		"canonical: y",
 		`canonical: "y"`,
-	}, {
+	},
+	{
 		"answer: n",
 		`answer: "n"`,
-	}, {
+	},
+	{
 		"answer: NO",
 		`answer: "NO"`,
-	}, {
+	},
+	{
 		"logical: True",
 		"logical: true",
-	}, {
+	},
+	{
 		"option: on",
 		`option: "on"`,
-	}, {
+	},
+	{
 		"answer: off",
 		`answer: "off"`,
 	},
@@ -119,25 +141,32 @@ var unmarshalTests = []struct {
 	{
 		"canonical: 685230",
 		"canonical: 685230",
-	}, {
+	},
+	{
 		"decimal: +685_230",
 		"decimal: +685_230",
-	}, {
+	},
+	{
 		"octal: 02472256",
 		"octal: 0o2472256",
-	}, {
+	},
+	{
 		"hexa: 0x_0A_74_AE",
 		"hexa: 0x_0A_74_AE",
-	}, {
+	},
+	{
 		"bin: 0b1010_0111_0100_1010_1110",
 		"bin: 0b1010_0111_0100_1010_1110",
-	}, {
+	},
+	{
 		"bin: -0b101010",
 		"bin: -0b101010",
-	}, {
+	},
+	{
 		"bin: -0b1000000000000000000000000000000000000000000000000000000000000000",
 		"bin: -0b1000000000000000000000000000000000000000000000000000000000000000",
-	}, {
+	},
+	{
 		"decimal: +685_230",
 		"decimal: +685_230",
 	},
@@ -148,25 +177,32 @@ var unmarshalTests = []struct {
 	{
 		"empty:",
 		"empty: null",
-	}, {
+	},
+	{
 		"canonical: ~",
 		"canonical: null",
-	}, {
+	},
+	{
 		"english: null",
 		"english: null",
-	}, {
+	},
+	{
 		"_foo: 1",
 		`"_foo": 1`,
-	}, {
+	},
+	{
 		`"#foo": 1`,
 		`"#foo": 1`,
-	}, {
+	},
+	{
 		"_#foo: 1",
 		`"_#foo": 1`,
-	}, {
+	},
+	{
 		"~: null key",
 		`"null": "null key"`,
-	}, {
+	},
+	{
 		`empty:
 apple: "newline"`,
 		`empty: null
@@ -177,10 +213,12 @@ apple: "newline"`,
 	{
 		"seq: [A,B]",
 		`seq: ["A", "B"]`,
-	}, {
+	},
+	{
 		"seq: [A,B,C,]",
 		`seq: ["A", "B", "C"]`,
-	}, {
+	},
+	{
 		"seq: [A,1,C]",
 		`seq: ["A", 1, "C"]`,
 	},
@@ -191,14 +229,16 @@ apple: "newline"`,
 	"A",
 	"B",
 ]`,
-	}, {
+	},
+	{
 		"seq:\n - A\n - B\n - C",
 		`seq: [
 	"A",
 	"B",
 	"C",
 ]`,
-	}, {
+	},
+	{
 		"seq:\n - A\n - 1\n - C",
 		`seq: [
 	"A",
@@ -242,25 +282,32 @@ apple: "newline"`,
 	{
 		"hello: world",
 		`hello: "world"`,
-	}, {
+	},
+	{
 		"a:",
 		"a: null",
-	}, {
+	},
+	{
 		"a: 1",
 		"a: 1",
-	}, {
+	},
+	{
 		"a: 1.0",
 		"a: 1.0",
-	}, {
+	},
+	{
 		"a: [1, 2]",
 		"a: [1, 2]",
-	}, {
+	},
+	{
 		"a: y",
 		`a: "y"`,
-	}, {
+	},
+	{
 		"{ a: 1, b: {c: 1} }",
 		`a: 1, b: {c: 1}`,
-	}, {
+	},
+	{
 		`
 True: 1
 Null: 1
@@ -275,13 +322,16 @@ Null: 1
 	{
 		"v: 42",
 		"v: 42",
-	}, {
+	},
+	{
 		"v: -42",
 		"v: -42",
-	}, {
+	},
+	{
 		"v: 4294967296",
 		"v: 4294967296",
-	}, {
+	},
+	{
 		"v: -4294967296",
 		"v: -4294967296",
 	},
@@ -382,7 +432,8 @@ Null: 1
 	{
 		"v: 4294967297",
 		"v: 4294967297",
-	}, {
+	},
+	{
 		"v: 128",
 		"v: 128",
 	},
@@ -391,7 +442,8 @@ Null: 1
 	{
 		"'1': '\"2\"'",
 		`"1": "\"2\""`,
-	}, {
+	},
+	{
 		"v:\n- A\n- 'B\n\n  C'\n",
 		`v: [
 	"A",
@@ -400,7 +452,8 @@ Null: 1
 		C
 		""",
 ]`,
-	}, {
+	},
+	{
 		`"\0"`,
 		`"\u0000"`,
 	},
@@ -409,16 +462,20 @@ Null: 1
 	{
 		"v: !!float '1.1'",
 		"v: 1.1",
-	}, {
+	},
+	{
 		"v: !!float 0",
 		"v: float & 0", // Should this be 0.0?
-	}, {
+	},
+	{
 		"v: !!float -1",
 		"v: float & -1", // Should this be -1.0?
-	}, {
+	},
+	{
 		"v: !!null ''",
 		"v: null",
-	}, {
+	},
+	{
 		"%TAG !y! tag:yaml.org,2002:\n---\nv: !y!int '1'",
 		"v: 1",
 	},
@@ -437,13 +494,15 @@ Null: 1
 b: 2
 c: 1
 d: 2`,
-	}, {
+	},
+	{
 		"a: &a {c: 1}\nb: *a",
 		`a: {c: 1}
 b: {
 	c: 1
 }`,
-	}, {
+	},
+	{
 		"a: &a [1, 2]\nb: *a",
 		"a: [1, 2]\nb: [1, 2]", // TODO: a: [1, 2], b: a
 	},
@@ -451,7 +510,8 @@ b: {
 	{
 		"foo: ''",
 		`foo: ""`,
-	}, {
+	},
+	{
 		"foo: null",
 		"foo: null",
 	},
@@ -524,10 +584,12 @@ b: {
 	{
 		"a: !!binary gIGC\n",
 		`a: '\x80\x81\x82'`,
-	}, {
+	},
+	{
 		"a: !!binary |\n  " + strings.Repeat("kJCQ", 17) + "kJ\n  CQ\n",
 		"a: '" + strings.Repeat(`\x90`, 54) + "'",
-	}, {
+	},
+	{
 		"a: !!binary |\n  " + strings.Repeat("A", 70) + "\n  ==\n",
 		"a: '" + strings.Repeat(`\x00`, 52) + "'",
 	},
@@ -678,7 +740,8 @@ a:
 	{
 		"a: 123456e1\n",
 		`a: 123456e1`,
-	}, {
+	},
+	{
 		"a: 123456E1\n",
 		`a: 123456e1`,
 	},
@@ -926,7 +989,7 @@ func TestFiles(t *testing.T) {
 			}
 			got := cueStr(expr)
 			if cuetest.UpdateGoldenFiles {
-				os.WriteFile(filename, []byte(got), 0644)
+				os.WriteFile(filename, []byte(got), 0o644)
 				return
 			}
 			b, err := os.ReadFile(filename)

--- a/internal/third_party/yaml/parserc.go
+++ b/internal/third_party/yaml/parserc.go
@@ -98,7 +98,7 @@ func yaml_parser_set_parser_error_context(parser *yaml_parser_t, context string,
 
 // State dispatcher.
 func yaml_parser_state_machine(parser *yaml_parser_t, event *yaml_event_t) bool {
-	//trace("yaml_parser_state_machine", "state:", parser.state.String())
+	// trace("yaml_parser_state_machine", "state:", parser.state.String())
 
 	switch parser.state {
 	case yaml_PARSE_STREAM_START_STATE:
@@ -207,7 +207,6 @@ func yaml_parser_parse_stream_start(parser *yaml_parser_t, event *yaml_event_t) 
 //
 //	*************************
 func yaml_parser_parse_document_start(parser *yaml_parser_t, event *yaml_event_t, implicit bool) bool {
-
 	token := peek_token(parser)
 	if token == nil {
 		return false
@@ -380,7 +379,7 @@ func yaml_parser_parse_document_end(parser *yaml_parser_t, event *yaml_event_t) 
 //
 //	******
 func yaml_parser_parse_node(parser *yaml_parser_t, event *yaml_event_t, block, indentless_sequence bool) bool {
-	//defer trace("yaml_parser_parse_node", "block:", block, "indentless_sequence:", indentless_sequence)()
+	// defer trace("yaml_parser_parse_node", "block:", block, "indentless_sequence:", indentless_sequence)()
 
 	token := peek_token(parser)
 	if token == nil {
@@ -1034,8 +1033,8 @@ var default_tag_directives = []yaml_tag_directive_t{
 
 // Parse directives.
 func yaml_parser_process_directives(parser *yaml_parser_t, version_directive_ref **yaml_version_directive_t,
-	tag_directives_ref *[]yaml_tag_directive_t) bool {
-
+	tag_directives_ref *[]yaml_tag_directive_t,
+) bool {
 	var version_directive *yaml_version_directive_t
 	var tag_directives []yaml_tag_directive_t
 

--- a/internal/third_party/yaml/readerc.go
+++ b/internal/third_party/yaml/readerc.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Set the reader error and return 0.
-func yaml_parser_set_reader_error(parser *yaml_parser_t, problem string, offset int, value int) bool {
+func yaml_parser_set_reader_error(parser *yaml_parser_t, problem string, offset, value int) bool {
 	parser.error = yaml_READER_ERROR
 	parser.problem = problem
 	parser.problem_offset = offset
@@ -104,7 +104,7 @@ func yaml_parser_update_buffer(parser *yaml_parser_t, length int) bool {
 		// given length in the buffer. Not doing that means every single
 		// check that calls this function to make sure the buffer has a
 		// given length is Go) panicking; or C) accessing invalid memory.
-		//return true
+		// return true
 	}
 
 	// Return if the buffer contains enough characters.

--- a/internal/third_party/yaml/resolve.go
+++ b/internal/third_party/yaml/resolve.go
@@ -14,8 +14,10 @@ type resolveMapItem struct {
 	tag   string
 }
 
-var resolveTable = make([]byte, 256)
-var resolveMap = make(map[string]resolveMapItem)
+var (
+	resolveTable = make([]byte, 256)
+	resolveMap   = make(map[string]resolveMapItem)
+)
 
 func init() {
 	t := resolveTable
@@ -29,7 +31,7 @@ func init() {
 	}
 	t[int('.')] = '.' // Float (potentially in map)
 
-	var resolveMapList = []struct {
+	resolveMapList := []struct {
 		v   interface{}
 		tag string
 		l   []string

--- a/internal/third_party/yaml/scannerc.go
+++ b/internal/third_party/yaml/scannerc.go
@@ -982,7 +982,6 @@ func yaml_parser_unroll_indent(parser *yaml_parser_t, column int) bool {
 
 // Initialize the scanner and produce the STREAM-START token.
 func yaml_parser_fetch_stream_start(parser *yaml_parser_t) bool {
-
 	// Set the initial indentation.
 	parser.indent = -1
 
@@ -1008,7 +1007,6 @@ func yaml_parser_fetch_stream_start(parser *yaml_parser_t) bool {
 
 // Produce the STREAM-END token and shut down the scanner.
 func yaml_parser_fetch_stream_end(parser *yaml_parser_t) bool {
-
 	// Force new line.
 	if parser.mark.column != 0 {
 		parser.mark.column = 0
@@ -1227,7 +1225,6 @@ func yaml_parser_fetch_block_entry(parser *yaml_parser_t) bool {
 
 // Produce the KEY token.
 func yaml_parser_fetch_key(parser *yaml_parser_t) bool {
-
 	// In the block context, additional checks are required.
 	if parser.flow_level == 0 {
 		// Check if we are allowed to start a new key (not nessesary simple).
@@ -1266,7 +1263,6 @@ func yaml_parser_fetch_key(parser *yaml_parser_t) bool {
 
 // Produce the VALUE token.
 func yaml_parser_fetch_value(parser *yaml_parser_t) bool {
-
 	simple_key := &parser.simple_keys[len(parser.simple_keys)-1]
 
 	// Have we found a simple key?
@@ -1426,7 +1422,6 @@ func yaml_parser_fetch_plain_scalar(parser *yaml_parser_t) bool {
 
 // Eat whitespaces and comments until the next token is found.
 func yaml_parser_scan_to_next_token(parser *yaml_parser_t) bool {
-
 	parser.linesSinceLast = 0
 	parser.spacesSinceLast = 0
 
@@ -1688,7 +1683,6 @@ const max_number_length = 2
 //	%YAML   1.1     # a comment \n
 //	          ^
 func yaml_parser_scan_version_directive_number(parser *yaml_parser_t, start_mark yaml_mark_t, number *int8) bool {
-
 	// Repeat while the next character is digit.
 	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
 		return false
@@ -1970,7 +1964,7 @@ func yaml_parser_scan_tag_handle(parser *yaml_parser_t, directive bool, start_ma
 
 // Scan a tag.
 func yaml_parser_scan_tag_uri(parser *yaml_parser_t, directive bool, head []byte, start_mark yaml_mark_t, uri *[]byte) bool {
-	//size_t length = head ? strlen((char *)head) : 0
+	// size_t length = head ? strlen((char *)head) : 0
 	var s []byte
 	hasTag := len(head) > 0
 
@@ -2028,7 +2022,6 @@ func yaml_parser_scan_tag_uri(parser *yaml_parser_t, directive bool, head []byte
 
 // Decode an URI-escape sequence corresponding to a single UTF-8 character.
 func yaml_parser_scan_uri_escapes(parser *yaml_parser_t, directive bool, start_mark yaml_mark_t, s *[]byte) bool {
-
 	// Decode the required number of characters.
 	w := 1024
 	for w > 0 {
@@ -2369,7 +2362,6 @@ func yaml_parser_scan_flow_scalar(parser *yaml_parser_t, token *yaml_token_t, si
 			} else if !single && parser.buffer[parser.buffer_pos] == '"' {
 				// It is a right double quote.
 				break
-
 			} else if !single && parser.buffer[parser.buffer_pos] == '\\' && is_break(parser.buffer, parser.buffer_pos+1) {
 				// It is an escaped line break.
 				if parser.unread < 3 && !yaml_parser_update_buffer(parser, 3) {
@@ -2578,10 +2570,9 @@ func yaml_parser_scan_flow_scalar(parser *yaml_parser_t, token *yaml_token_t, si
 
 // Scan a plain scalar.
 func yaml_parser_scan_plain_scalar(parser *yaml_parser_t, token *yaml_token_t) bool {
-
 	var s, leading_break, trailing_breaks, whitespaces []byte
 	var leading_blanks bool
-	var indent = parser.indent + 1
+	indent := parser.indent + 1
 
 	start_mark := parser.mark
 	end_mark := parser.mark

--- a/internal/third_party/yaml/yaml.go
+++ b/internal/third_party/yaml/yaml.go
@@ -143,8 +143,10 @@ type fieldInfo struct {
 	Inline []int
 }
 
-var structMap = make(map[reflect.Type]*structInfo)
-var fieldMapMutex sync.RWMutex
+var (
+	structMap     = make(map[reflect.Type]*structInfo)
+	fieldMapMutex sync.RWMutex
+)
 
 func getStructInfo(st reflect.Type) (*structInfo, error) {
 	fieldMapMutex.RLock()
@@ -222,7 +224,7 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 					fieldsList = append(fieldsList, finfo)
 				}
 			default:
-				//return nil, errors.New("Option ,inline needs a struct value or map field")
+				// return nil, errors.New("Option ,inline needs a struct value or map field")
 				return nil, errors.New("Option ,inline needs a struct value field")
 			}
 			continue

--- a/internal/third_party/yaml/yamlh.go
+++ b/internal/third_party/yaml/yamlh.go
@@ -263,7 +263,6 @@ func (e yaml_event_type_t) String() string {
 
 // The event structure.
 type yaml_event_t struct {
-
 	// The event type.
 	typ yaml_event_type_t
 
@@ -377,12 +376,10 @@ type yaml_node_t struct {
 
 	start_mark yaml_mark_t // The beginning of the node.
 	end_mark   yaml_mark_t // The end of the node.
-
 }
 
 // The document structure.
 type yaml_document_t struct {
-
 	// The document nodes.
 	nodes []yaml_node_t
 
@@ -530,7 +527,6 @@ type yaml_comment_t struct {
 // All members are internal. Manage the structure using the
 // yaml_parser_ family of functions.
 type yaml_parser_t struct {
-
 	// Error handling
 
 	filename string
@@ -660,7 +656,6 @@ const (
 // All members are internal.  Manage the structure using the @c yaml_emitter_
 // family of functions.
 type yaml_emitter_t struct {
-
 	// Error handling
 
 	error   yaml_error_type_t // Error type.

--- a/internal/third_party/yaml/yamlprivateh.go
+++ b/internal/third_party/yaml/yamlprivateh.go
@@ -94,7 +94,7 @@ func is_tab(b []byte, i int) bool {
 
 // Check if the character at the specified position is blank (space or tab).
 func is_blank(b []byte, i int) bool {
-	//return is_space(b, i) || is_tab(b, i)
+	// return is_space(b, i) || is_tab(b, i)
 	return b[i] == ' ' || b[i] == '\t'
 }
 
@@ -113,7 +113,7 @@ func is_crlf(b []byte, i int) bool {
 
 // Check if the character is a line break or NUL.
 func is_breakz(b []byte, i int) bool {
-	//return is_break(b, i) || is_z(b, i)
+	// return is_break(b, i) || is_z(b, i)
 	return (        // is_break:
 	b[i] == '\r' || // CR (#xD)
 		b[i] == '\n' || // LF (#xA)
@@ -126,7 +126,7 @@ func is_breakz(b []byte, i int) bool {
 
 // Check if the character is a line break, space, or NUL.
 func is_spacez(b []byte, i int) bool {
-	//return is_space(b, i) || is_breakz(b, i)
+	// return is_space(b, i) || is_breakz(b, i)
 	return ( // is_space:
 	b[i] == ' ' ||
 		// is_breakz:
@@ -140,7 +140,7 @@ func is_spacez(b []byte, i int) bool {
 
 // Check if the character is a line break, space, tab, or NUL.
 func is_blankz(b []byte, i int) bool {
-	//return is_blank(b, i) || is_breakz(b, i)
+	// return is_blank(b, i) || is_breakz(b, i)
 	return ( // is_blank:
 	b[i] == ' ' || b[i] == '\t' ||
 		// is_breakz:
@@ -169,5 +169,4 @@ func width(b byte) int {
 		return 4
 	}
 	return 0
-
 }

--- a/pkg/crypto/ed25519/ed25519_test.go
+++ b/pkg/crypto/ed25519/ed25519_test.go
@@ -84,7 +84,7 @@ func updateGoldenFiles(t *testing.T) {
 	var buf bytes.Buffer
 	fmt.Fprintln(&buf, "-- in.cue --")
 	fmt.Fprintf(&buf, "%s", fInputs)
-	if err := os.WriteFile("testdata/gen.txtar", buf.Bytes(), 0666); err != nil {
+	if err := os.WriteFile("testdata/gen.txtar", buf.Bytes(), 0o666); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/pkg/crypto/hmac/hmac.go
+++ b/pkg/crypto/hmac/hmac.go
@@ -44,7 +44,7 @@ const (
 //
 // Supported hash functions: "MD5", "SHA1", "SHA224", "SHA256", "SHA384", "SHA512", "SHA512_224",
 // and "SHA512_256".
-func Sign(hashName string, key []byte, data []byte) ([]byte, error) {
+func Sign(hashName string, key, data []byte) ([]byte, error) {
 	hash, err := hashFromName(hashName)
 	if err != nil {
 		return nil, err

--- a/pkg/gen.go
+++ b/pkg/gen.go
@@ -190,7 +190,7 @@ func generate(pkg *packages.Package) error {
 
 	filename := filepath.Join(pkgDir, genFile)
 
-	if err := os.WriteFile(filename, b, 0666); err != nil {
+	if err := os.WriteFile(filename, b, 0o666); err != nil {
 		return err
 	}
 	return nil
@@ -438,7 +438,7 @@ var errNoCUEFiles = errors.New("no CUE files in directory")
 // library, we don't want that cyclic dependency.
 // It only has to deal with the fairly limited subset of CUE packages that are
 // present inside pkg/....
-func loadCUEPackage(ctx *cue.Context, dir string, pkgPath string) (cue.Value, error) {
+func loadCUEPackage(ctx *cue.Context, dir, pkgPath string) (cue.Value, error) {
 	inst := &build.Instance{
 		PkgName:     path.Base(pkgPath),
 		Dir:         dir,

--- a/pkg/path/path_p9.go
+++ b/pkg/path/path_p9.go
@@ -20,8 +20,10 @@ package path
 
 import "strings"
 
-const plan9Separator = '/'
-const plan9ListSeparator = '\000'
+const (
+	plan9Separator     = '/'
+	plan9ListSeparator = '\000'
+)
 
 type plan9Info struct{}
 

--- a/pkg/path/path_test.go
+++ b/pkg/path/path_test.go
@@ -148,7 +148,7 @@ func TestFromAndToSlash(t *testing.T) {
 	for _, o := range []OS{Unix, Windows, Plan9} {
 		sep := getOS(o).Separator
 
-		var slashtests = []PathTest{
+		slashtests := []PathTest{
 			{"", ""},
 			{"/", string(sep)},
 			{"/a/b", string([]byte{sep, 'a', sep, 'b'})},

--- a/pkg/path/path_windows_test.go
+++ b/pkg/path/path_windows_test.go
@@ -40,11 +40,11 @@ func TestWinSplitListTestsAreValid(t *testing.T) {
 }
 
 func testWinSplitListTestIsValid(t *testing.T, ti int, tt SplitListTest,
-	comspec string) {
-
+	comspec string,
+) {
 	const (
 		cmdfile = `printdir.cmd`
-		perm    = 0700
+		perm    = 0o700
 	)
 
 	tmp := t.TempDir()

--- a/pkg/path/pkg.go
+++ b/pkg/path/pkg.go
@@ -41,7 +41,8 @@ var (
 		Values: append([]adt.Value{
 			newStr("windows"),
 			newStr("unix"),
-			newStr("plan9")}, unixOS...),
+			newStr("plan9"),
+		}, unixOS...),
 	}
 
 	allOS = append([]adt.Value{

--- a/pkg/qgo.go
+++ b/pkg/qgo.go
@@ -155,7 +155,7 @@ func extract(args []string) {
 			if err != nil {
 				log.Fatal(err)
 			}
-			err = os.WriteFile(lastPkg+".go", b, 0644)
+			err = os.WriteFile(lastPkg+".go", b, 0o644)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/regexp/regexp.go
+++ b/pkg/regexp/regexp.go
@@ -25,7 +25,7 @@ import "regexp"
 // Match reports whether the string s
 // contains any match of the regular expression pattern.
 // More complicated queries need to use Compile and the full Regexp interface.
-func Match(pattern string, s string) (matched bool, err error) {
+func Match(pattern, s string) (matched bool, err error) {
 	return regexp.MatchString(pattern, s)
 }
 

--- a/pkg/strconv/strconv.go
+++ b/pkg/strconv/strconv.go
@@ -93,7 +93,7 @@ func ParseFloat(s string, bitSize int) (float64, error) {
 const IntSize = 64
 
 // ParseUint is like ParseInt but for unsigned numbers.
-func ParseUint(s string, base int, bitSize int) (uint64, error) {
+func ParseUint(s string, base, bitSize int) (uint64, error) {
 	return strconv.ParseUint(s, base, bitSize)
 }
 
@@ -117,7 +117,7 @@ func ParseUint(s string, base int, bitSize int) (uint64, error) {
 // signed integer of the given size, err.Err = ErrRange and the
 // returned value is the maximum magnitude integer of the
 // appropriate bitSize and sign.
-func ParseInt(s string, base int, bitSize int) (i int64, err error) {
+func ParseInt(s string, base, bitSize int) (i int64, err error) {
 	return strconv.ParseInt(s, base, bitSize)
 }
 

--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -215,7 +215,7 @@ func Parse(layout, value string) (string, error) {
 // It is valid to pass nsec outside the range [0, 999999999].
 // Not all sec values have a corresponding time value. One such
 // value is 1<<63-1 (the largest int64 value).
-func Unix(sec int64, nsec int64) string {
+func Unix(sec, nsec int64) string {
 	t := time.Unix(sec, nsec)
 	return t.UTC().Format(time.RFC3339Nano)
 }

--- a/pkg/tool/file/file.go
+++ b/pkg/tool/file/file.go
@@ -41,13 +41,15 @@ func newMkdirCmd(v cue.Value) (task.Runner, error)     { return &cmdMkdir{}, nil
 func newMkdirTempCmd(v cue.Value) (task.Runner, error) { return &cmdMkdirTemp{}, nil }
 func newRemoveAllCmd(v cue.Value) (task.Runner, error) { return &cmdRemoveAll{}, nil }
 
-type cmdRead struct{}
-type cmdAppend struct{}
-type cmdCreate struct{}
-type cmdGlob struct{}
-type cmdMkdir struct{}
-type cmdMkdirTemp struct{}
-type cmdRemoveAll struct{}
+type (
+	cmdRead      struct{}
+	cmdAppend    struct{}
+	cmdCreate    struct{}
+	cmdGlob      struct{}
+	cmdMkdir     struct{}
+	cmdMkdirTemp struct{}
+	cmdRemoveAll struct{}
+)
 
 func (c *cmdRead) Run(ctx *task.Context) (res interface{}, err error) {
 	filename := ctx.String("filename")

--- a/pkg/tool/file/file_test.go
+++ b/pkg/tool/file/file_test.go
@@ -226,5 +226,4 @@ func TestMkdirTemp(t *testing.T) {
 	if err == nil {
 		t.Fatal(err)
 	}
-
 }

--- a/pkg/tool/os/env_test.go
+++ b/pkg/tool/os/env_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func TestGetenv(t *testing.T) {
-
 	for _, p := range [][2]string{
 		{"CUEOSTESTMOOD", "yippie"},
 		{"CUEOSTESTTRUE", "True"},
@@ -91,7 +90,7 @@ func TestGetenv(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		var opts = []cmp.Option{
+		opts := []cmp.Option{
 			cmpopts.IgnoreFields(ast.BinaryExpr{}, "OpPos"),
 			cmpopts.IgnoreFields(ast.BasicLit{}, "ValuePos"),
 			cmpopts.IgnoreUnexported(ast.BasicLit{}, ast.BinaryExpr{}),

--- a/tools/flow/flow.go
+++ b/tools/flow/flow.go
@@ -247,7 +247,6 @@ func New(cfg *Config, inst cue.InstanceOrValue, f TaskFunc) *Controller {
 
 	c.initTasks()
 	return c
-
 }
 
 // Run runs the tasks of a workflow until completion.
@@ -448,7 +447,6 @@ func (t *Task) addDep(path string, dep *Task) {
 	}
 	if !found {
 		t.pathDeps[path] = append(a, dep)
-
 	}
 
 	if !t.deps[dep] {

--- a/tools/flow/run.go
+++ b/tools/flow/run.go
@@ -158,7 +158,6 @@ func (c *Controller) markReady(t *Task) {
 // updateValue recomputes the workflow configuration if it is out of date. It
 // reports whether the values were updated.
 func (c *Controller) updateValue() bool {
-
 	if c.valueSeqNum == c.conjunctSeq {
 		return false
 	}

--- a/tools/flow/tasks.go
+++ b/tools/flow/tasks.go
@@ -80,7 +80,6 @@ func (c *Controller) findRootTasks(v cue.Value) {
 	for iter, _ := v.List(); iter.Next(); {
 		c.findRootTasks(iter.Value())
 	}
-
 }
 
 // This file contains the functionality to locate and record the tasks of

--- a/tools/trim/trim_test.go
+++ b/tools/trim/trim_test.go
@@ -282,7 +282,6 @@ func TestData(t *testing.T) {
 	}
 
 	test.Run(t, func(t *cuetxtar.Test) {
-
 		a := t.Instance()
 		val := cuecontext.New().BuildInstance(a)
 		// Note: don't check val.Err because there are deliberate


### PR DESCRIPTION
Format and simplify code inline with gofumpt:

```sh
gofumpt -extra -w .
```