### PR TITLE
fix(format): remove leading whitespace from lists

### DIFF
--- a/cmd/cue/cmd/eval.go
+++ b/cmd/cue/cmd/eval.go
@@ -42,7 +42,7 @@ configuration file, instead of the entire configuration file itself.
 Examples:
 
   $ cat <<EOF > foo.cue
-  a: [ "a", "b", "c" ]
+  a: ["a", "b", "c"]
   EOF
 
   $ cue eval foo.cue -e a[0] -e a[2]

--- a/cmd/cue/cmd/root.go
+++ b/cmd/cue/cmd/root.go
@@ -140,7 +140,7 @@ Commands are defined in CUE as follows:
 	command: deploy: {
 		exec.Run
 		cmd:   "kubectl"
-		args:  [ "-f", "deploy" ]
+		args:  ["-f", "deploy"]
 		in:    json.Encode(userValue) // encode the emitted configuration.
 	}
 

--- a/cmd/cue/cmd/testdata/script/help.txtar
+++ b/cmd/cue/cmd/testdata/script/help.txtar
@@ -19,7 +19,7 @@ Commands are defined in CUE as follows:
 	command: deploy: {
 		exec.Run
 		cmd:   "kubectl"
-		args:  [ "-f", "deploy" ]
+		args:  ["-f", "deploy"]
 		in:    json.Encode(userValue) // encode the emitted configuration.
 	}
 

--- a/cue/format/node.go
+++ b/cue/format/node.go
@@ -649,7 +649,7 @@ func (f *formatter) exprRaw(expr ast.Expr, prec1, depth int) {
 		f.print(ws, x.Rbrace, token.RBRACE)
 
 	case *ast.ListLit:
-		f.print(x.Lbrack, token.LBRACK, indent)
+		f.print(x.Lbrack, token.LBRACK, noblank, indent)
 		f.walkListElems(x.Elts)
 		f.print(trailcomma, noblank)
 		f.visitComments(f.current.pos)

--- a/cue/format/testdata/expressions.golden
+++ b/cue/format/testdata/expressions.golden
@@ -142,10 +142,10 @@ package expressions
 	e: [...int]
 	e: [...int]
 	e: [...int | float]
-	e: [ for x in someObject if x > 9 {
+	e: [for x in someObject if x > 9 {
 		x
 	}]
-	e: [ for x in someObject if x > 9 {x}]
+	e: [for x in someObject if x > 9 {x}]
 	e: [
 		for x in someObject
 		if x > 9 {x}]
@@ -235,4 +235,16 @@ package expressions
 
 	"contains		tabs": 123
 	@jsonschema(foo="contains		tabs")
+
+	g: [1, 2, 3]
+	g: [1, 2, 3]
+	g: [1, 2, 3]
+	g: [1, 2, 3]
+	g: [1, 2, 3]
+	g: [1, 2, 3]
+	g: [1, 2, 3]
+	g: [1, 2, 3]
+	g: [if true {1}, 2, 3]
+	h: [1]
+	i: [{}]
 }

--- a/cue/format/testdata/expressions.input
+++ b/cue/format/testdata/expressions.input
@@ -5,7 +5,7 @@ package expressions
     aaa: 22 // comment
 
     "": 3
-    
+
     b: 3
 
     c: b: a:  4
@@ -171,7 +171,7 @@ package expressions
             "\(k)":v
         }
     }
-    
+
     e: { for k, v in someObject if k > "a" {"\(k)":v} }
     e: { for k, v in someObject if k > "a" {
         "\(k)":v }}
@@ -232,4 +232,16 @@ package expressions
 
     "contains		tabs": 123
     @jsonschema(foo="contains		tabs")
+
+    g: [ 1, 2, 3]
+    g: [ 1, 2, 3,]
+    g: [ 1, 2, 3, ]
+    g: [ 1, 2, 3 ]
+    g: [1, 2, 3,]
+    g: [ 1, 2, 3, ]
+    g: [    1, 2, 3,]
+    g: [     1, 2, 3,]
+    g: [ if true { 1 }, 2, 3]
+    h: [ 1]
+    i: [ {}]
 }

--- a/cue/parser/parser_test.go
+++ b/cue/parser/parser_test.go
@@ -310,7 +310,7 @@ func TestParse(t *testing.T) {
 		"list comprehensions",
 		`{
 				y: [1,2,3]
-				b: [ for x in y if x == 1 { x } ],
+				b: [for x in y if x == 1 { x } ],
 			}`,
 		`{y: [1, 2, 3], b: [for x in y if x==1 {x}]}`,
 	}, {

--- a/doc/ref/spec.md
+++ b/doc/ref/spec.md
@@ -2625,7 +2625,7 @@ LetClause           = "let" identifier "=" Expression .
 
 ```
 a: [1, 2, 3, 4]
-b: [ for x in a if x > 1 { x+1 } ]  // [3, 4, 5]
+b: [for x in a if x > 1 { x+1 } ]  // [3, 4, 5]
 
 c: {
     for x in a

--- a/doc/tutorial/basics/6_expressions/40_listcomp.txtar
+++ b/doc/tutorial/basics/6_expressions/40_listcomp.txtar
@@ -11,7 +11,7 @@ Lists can be created with list comprehensions.
 The example shows the use of `for` loops and `if` guards.
 
 -- listcomp.cue --
-[ for x in #items if x rem 2 == 0 { x*x } ]
+[for x in #items if x rem 2 == 0 { x*x } ]
 
 #items: [ 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
 

--- a/doc/tutorial/kubernetes/README.md
+++ b/doc/tutorial/kubernetes/README.md
@@ -886,7 +886,7 @@ We create the tool file to do just that.
 $ cat <<EOF > kube_tool.cue
 package kube
 
-objects: [ for v in objectSets for x in v {x}]
+objects: [for v in objectSets for x in v {x}]
 
 objectSets: [
 	service,
@@ -1202,7 +1202,7 @@ The next step is to pull common fields, such as `image` to the top level.
 Arguments can be specified as a map.
 ```
     arg: [string]: string
-    args: [ for k, v in arg { "-\(k)=\(v)" } ] | [...string]
+    args: [for k, v in arg { "-\(k)=\(v)" } ] | [...string]
 ```
 
 If order matters, users could explicitly specify the list as well.
@@ -1307,7 +1307,7 @@ kubernetes: services: {
             metadata: labels: x.label
             spec: selector:   x.label
 
-            spec: ports: [ for p in x.port { p } ]
+            spec: ports: [for p in x.port { p } ]
         }
     }
 }

--- a/doc/tutorial/kubernetes/manual/services/cloud.cue
+++ b/doc/tutorial/kubernetes/manual/services/cloud.cue
@@ -26,7 +26,7 @@ deployment: [Name=_]: _base & {
 	port: [string]: int
 
 	arg: [string]: string
-	args: *[ for k, v in arg {"-\(k)=\(v)"}] | [...string]
+	args: *[for k, v in arg {"-\(k)=\(v)"}] | [...string]
 
 	// Environment variables
 	env: [string]: string

--- a/doc/tutorial/kubernetes/manual/services/k8s.cue
+++ b/doc/tutorial/kubernetes/manual/services/k8s.cue
@@ -10,7 +10,7 @@ kubernetes: services: {
 			metadata: labels: x.label
 			spec: selector:   x.label
 
-			spec: ports: [ for p in x.port {p}] // convert struct to list
+			spec: ports: [for p in x.port {p}] // convert struct to list
 		}
 	}
 	// Note that we cannot write
@@ -84,10 +84,10 @@ _k8sSpec: X: kubernetes: {
 			image: X.image
 			args:  X.args
 			if len(X.envSpec) > 0 {
-				env: [ for k, v in X.envSpec {v, name: k}]
+				env: [for k, v in X.envSpec {v, name: k}]
 			}
 
-			ports: [ for k, p in X.expose.port & X.port {
+			ports: [for k, p in X.expose.port & X.port {
 				name:          k
 				containerPort: p
 			}]

--- a/doc/tutorial/kubernetes/manual/services/kube_tool.cue
+++ b/doc/tutorial/kubernetes/manual/services/kube_tool.cue
@@ -1,6 +1,6 @@
 package kube
 
-objects: [ for v in objectSets for x in v { x } ]
+objects: [for v in objectSets for x in v { x } ]
 
 objectSets: [
 	kubernetes.services,

--- a/doc/tutorial/kubernetes/quick/services/kube_tool.cue
+++ b/doc/tutorial/kubernetes/quick/services/kube_tool.cue
@@ -1,6 +1,6 @@
 package kube
 
-objects: [ for v in objectSets for x in v {x}]
+objects: [for v in objectSets for x in v {x}]
 
 objectSets: [
 	service,

--- a/encoding/protobuf/textproto/testdata/decoder/list.txtar
+++ b/encoding/protobuf/textproto/testdata/decoder/list.txtar
@@ -34,7 +34,7 @@ string1: [
 float1: [ 1e+2 1. 0]
 -- out/decode --
 empty1: []
-empty2: [ // foo
+empty2: [// foo
 ]
 int1: [1, 2]
 int2: [1, 2] // omitting commas okay

--- a/internal/ci/base/codereview.cue
+++ b/internal/ci/base/codereview.cue
@@ -21,7 +21,7 @@ import (
 // the key: value
 toCodeReviewCfg: {
 	#input: #codeReview
-	let parts = [ for k, v in #input {k + ": " + v}]
+	let parts = [for k, v in #input {k + ": " + v}]
 
 	// Per https://pkg.go.dev/golang.org/x/review/git-codereview#hdr-Configuration
 	strings.Join(parts, "\n")

--- a/internal/ci/base/github.cue
+++ b/internal/ci/base/github.cue
@@ -278,7 +278,7 @@ setupGoActionsCaches: {
 // but array literals are not yet supported in expressions.
 isProtectedBranch: {
 	#trailers: [...string]
-	"((" + strings.Join([ for branch in protectedBranchPatterns {
+	"((" + strings.Join([for branch in protectedBranchPatterns {
 		(_matchPattern & {variable: "github.ref", pattern: "refs/heads/\(branch)"}).expr
 	}], " || ") + ") && (! \(containsDispatchTrailer)))"
 }

--- a/internal/ci/ci_tool.cue
+++ b/internal/ci/ci_tool.cue
@@ -55,7 +55,7 @@ command: gen: {
 		for _workflowName, _workflow in github.workflows {
 			let _filename = _workflowName + repo.workflowFileExtension
 			"generate \(_filename)": file.Create & {
-				$after: [ for v in remove {v}]
+				$after: [for v in remove {v}]
 				filename: path.Join([_dir, _filename], _goos)
 				let donotedit = repo.doNotEditMessage & {#generatedBy: "internal/ci/ci_tool.cue", _}
 				contents: "# \(donotedit)\n\n\(yaml.Marshal(_workflow))"

--- a/internal/core/dep/testdata/dynamic.txtar
+++ b/internal/core/dep/testdata/dynamic.txtar
@@ -19,7 +19,7 @@ middle: {
 }
 
 a: {
-	b: [ for x in middle {x}]
+	b: [for x in middle {x}]
 	c: {}
 }
 -- out/dependencies/field --

--- a/internal/core/dep/testdata/listcomprehension.txtar
+++ b/internal/core/dep/testdata/listcomprehension.txtar
@@ -1,5 +1,5 @@
 -- in.cue --
-a: b: [ for x in c if x.a > 0 {x.a + d}]
+a: b: [for x in c if x.a > 0 {x.a + d}]
 
 c: [{a: 1}, {a: 3}]
 d: 2

--- a/internal/core/export/testdata/main/let.txtar
+++ b/internal/core/export/testdata/main/let.txtar
@@ -17,7 +17,7 @@ x: "foo"
 let Y = x
 y: Y
 -- issue593.cue --
-cfgs: [ for crd in ["one", "two"] {
+cfgs: [for crd in ["one", "two"] {
 	metadata: {
 		name: crd
 	}
@@ -137,7 +137,7 @@ let X = 1 + 1
 let Y = x
 let Y_1 = x
 {
-	cfgs: [ for crd in ["one", "two"] {
+	cfgs: [for crd in ["one", "two"] {
 		metadata: {
 			name: crd
 		}

--- a/internal/encoding/json/encode_test.go
+++ b/internal/encoding/json/encode_test.go
@@ -154,7 +154,7 @@ f4: {
 				a: 1
 				b: 3
 			}
-			c: [1, [ for x in m { x } ]]
+			c: [1, [for x in m { x } ]]
 			`,
 		out: "json: unsupported node for x in m {x} (*ast.Comprehension)",
 	}, {

--- a/internal/encoding/yaml/encode_test.go
+++ b/internal/encoding/yaml/encode_test.go
@@ -170,7 +170,7 @@ f4: {} # line 4
 				a: 1
 				b: 3
 			}
-			c: [1, [ for x in m {x}]]
+			c: [1, [for x in m {x}]]
 			`,
 		out: "yaml: unsupported node for x in m {x} (*ast.Comprehension)",
 	}, {

--- a/pkg/list/list.go
+++ b/pkg/list/list.go
@@ -149,7 +149,7 @@ func Repeat(x []cue.Value, count int) ([]cue.Value, error) {
 //
 // Concat([a, b, c]) is equivalent to
 //
-//	[ for x in a {x}, for x in b {x}, for x in c {x} ]
+//	[for x in a {x}, for x in b {x}, for x in c {x} ]
 func Concat(a []cue.Value) ([]cue.Value, error) {
 	var res []cue.Value
 	for _, e := range a {

--- a/tools/flow/testdata/dep.txtar
+++ b/tools/flow/testdata/dep.txtar
@@ -52,7 +52,7 @@ root: {
 	}
 
 	incompleteList: {
-		x: [ for x in [1] {incompleteComprehensionSource.x}]
+		x: [for x in [1] {incompleteComprehensionSource.x}]
 	}
 
 	incompleteGeneratedStruct: {

--- a/tools/flow/testdata/dynamic.txtar
+++ b/tools/flow/testdata/dynamic.txtar
@@ -16,7 +16,7 @@ root: {
 	// Run this after all generated tasks (so far)
 	b: {
 		$id: "list"
-		$after: [ for x in middle {x}]
+		$after: [for x in middle {x}]
 		out: [...int]
 	}
 	after: {

--- a/tools/flow/testdata/issue2416b.txtar
+++ b/tools/flow/testdata/issue2416b.txtar
@@ -22,7 +22,7 @@ for _, input in inputs {
 }
 
 root: print: cli.Print & {
-	text: strings.Join([ for key, val in outputs { "key=\(key) val=\(val)" } ], "\n")
+	text: strings.Join([for key, val in outputs { "key=\(key) val=\(val)" } ], "\n")
 }
 -- out/run/errors --
 -- out/run/t0 --

--- a/tools/trim/testdata/defaults.txtar
+++ b/tools/trim/testdata/defaults.txtar
@@ -59,7 +59,7 @@ issue781: {
 // was first used to select the default.
 dontEraseDefaultSelection: {
 	rule: _#Rule & {
-		verbs: [ "c"]
+		verbs: ["c"]
 	}
 	_#Rule: {
 		verbs: *["a", "b"] | ["c"]
@@ -127,7 +127,7 @@ issue781: {
 // was first used to select the default.
 dontEraseDefaultSelection: {
 	rule: _#Rule & {
-		verbs: [ "c"]
+		verbs: ["c"]
 	}
 	_#Rule: {
 		verbs: *["a", "b"] | ["c"]


### PR DESCRIPTION
Leading whitespace is not strictly enforced, but is incorrectly present when the formatting of a list is fixed. The behaviour can be made consistent by requesting no blanks at the start of a list.

```diff
-[ 1]
-[ for x in y {}]
+[1]
+ [for x in y {}]
```

Fixes: #1023