### PR TITLE
fix(format): indent list elements correctly

### DIFF
--- a/cmd/cue/cmd/testdata/script/get_go_types.txtar
+++ b/cmd/cue/cmd/testdata/script/get_go_types.txtar
@@ -266,12 +266,12 @@ import (
 	Slice1: [...int] @go(,[]int)
 	Slice2: [...] @go(,[]interface{})
 	Slice3?: null | [...] @go(,*[]json.Unmarshaler)
-	Array1:  5 * [int]    @go(,[5]int)
-	Array2:  5 * [_]      @go(,[5]interface{})
+	Array1: 5 * [int] @go(,[5]int)
+	Array2: 5 * [_] @go(,[5]interface{})
 	Array3?: null | 5*[_] @go(,*[5]json.Marshaler)
-	Array4:  bytes        @go(,[5]byte)
-	Intf:    #Interface   @protobuf(2,varint,name=intf)
-	Intf2:   _            @go(,interface{})
+	Array4: bytes      @go(,[5]byte)
+	Intf:   #Interface @protobuf(2,varint,name=intf)
+	Intf2:  _          @go(,interface{})
 	Intf3: {
 		Interface: #Interface
 	} @go(,struct{Interface})

--- a/cue/format/node.go
+++ b/cue/format/node.go
@@ -431,6 +431,16 @@ func (f *formatter) nextNeedsFormfeed(n ast.Expr) bool {
 		return strings.IndexByte(x.Value, '\n') >= 0
 	case *ast.ListLit:
 		return true
+	case *ast.UnaryExpr:
+		return f.nextNeedsFormfeed(x.X)
+	case *ast.BinaryExpr:
+		return f.nextNeedsFormfeed(x.X) || f.nextNeedsFormfeed(x.Y)
+	case *ast.CallExpr:
+		for _, arg := range x.Args {
+			if f.nextNeedsFormfeed(arg) {
+				return true
+			}
+		}
 	}
 	return false
 }

--- a/cue/format/testdata/expressions.golden
+++ b/cue/format/testdata/expressions.golden
@@ -1,5 +1,7 @@
 package expressions
 
+import "list"
+
 {
 	a:   1  // comment
 	aaa: 22 // comment
@@ -235,4 +237,20 @@ package expressions
 
 	"contains		tabs": 123
 	@jsonschema(foo="contains		tabs")
+
+	j: cueckoo: _ | [
+		1,
+
+		2,
+	]
+	k: cueckoo: *[
+		1,
+
+		2,
+	]
+	l: cueckoo: list.Concat([
+		1,
+
+		2,
+	])
 }

--- a/cue/format/testdata/expressions.input
+++ b/cue/format/testdata/expressions.input
@@ -1,11 +1,13 @@
 package expressions
 
+import "list"
+
 {
     a: 1 // comment
     aaa: 22 // comment
 
     "": 3
-    
+
     b: 3
 
     c: b: a:  4
@@ -171,7 +173,7 @@ package expressions
             "\(k)":v
         }
     }
-    
+
     e: { for k, v in someObject if k > "a" {"\(k)":v} }
     e: { for k, v in someObject if k > "a" {
         "\(k)":v }}
@@ -232,4 +234,20 @@ package expressions
 
     "contains		tabs": 123
     @jsonschema(foo="contains		tabs")
+
+    j: cueckoo: _ | [
+        1,
+
+        2,
+    ]
+    k: cueckoo: *[
+        1,
+
+        2,
+    ]
+    l: cueckoo: list.Concat([
+        1,
+
+        2,
+    ])
 }

--- a/encoding/jsonschema/testdata/list.txtar
+++ b/encoding/jsonschema/testdata/list.txtar
@@ -40,6 +40,6 @@ import "list"
 
 foo?: [...string]
 tuple?: [string, int, 2]
-has?:  list.Contains(3)
+has?: list.Contains(3)
 size?: list.UniqueItems() & list.MaxItems(9) & [_, _, _, ...]
 additional?: [int, int, ...string]

--- a/encoding/jsonschema/testdata/type.txtar
+++ b/encoding/jsonschema/testdata/type.txtar
@@ -32,7 +32,7 @@
 -- out.cue --
 // Main schema
 intString?: null | bool | int | string | [...]
-object?:    {
+object?: {
 	...
 } | *{
 	foo: "bar"

--- a/internal/core/export/testdata/main/adt.txtar
+++ b/internal/core/export/testdata/main/adt.txtar
@@ -44,7 +44,7 @@ l5: [1, 3] & {
 }
 
 #foo: int
-l6:   [1, #foo] & {
+l6: [1, #foo] & {
 	[1, 3]
 
 	#foo: int
@@ -180,7 +180,7 @@ l5: [1, 3] & {
 	#foo: int
 }
 #foo: int
-l6:   [1, #foo] & {
+l6: [1, #foo] & {
 	[1, 3]
 	#foo: int
 }
@@ -197,7 +197,7 @@ e5:  e1 + e2 - e3
 e6:  !t
 e7:  !t || !false
 e8?: !false
-m1:  {
+m1: {
 	[string]: int & >=0
 } & {
 	{

--- a/pkg/list/testdata/list.txtar
+++ b/pkg/list/testdata/list.txtar
@@ -168,7 +168,7 @@ unique: {
 // Issue #2099
 minItems: {
 	incomplete1: [...] & list.MinItems(1)
-	fail1:       _|_ // minItems.fail1: invalid value [] (does not satisfy list.MinItems(1)): len(list) < MinItems(1) (0 < 1) (and 1 more errors)
+	fail1: _|_ // minItems.fail1: invalid value [] (does not satisfy list.MinItems(1)): len(list) < MinItems(1) (0 < 1) (and 1 more errors)
 	ok1: [0, ...]
 	ok2: [0]
 }

--- a/pkg/struct/testdata/struct.txtar
+++ b/pkg/struct/testdata/struct.txtar
@@ -36,7 +36,7 @@ import "struct"
 
 minFields: {
 	incomplete1: {} & struct.MinFields(1)
-	fail1:       _|_ // minFields.fail1: invalid value {} (does not satisfy struct.MinFields(1)): len(fields) < MinFields(1) (0 < 1)
+	fail1: _|_ // minFields.fail1: invalid value {} (does not satisfy struct.MinFields(1)): len(fields) < MinFields(1) (0 < 1)
 	ok1: {
 		a: 1
 	}


### PR DESCRIPTION
Vertical tabs are not inserted when the next expression needs a form feed, but are erroneously inserted for expressions which hide the underlying type. This is fixed by recursively checking if expressions need a form feed.

Fixes: #2314