### PR TITLE
internal/core/export: fix issue #2584; add issue2584.txtar

### DIFF
--- a/internal/core/export/adt.go
+++ b/internal/core/export/adt.go
@@ -329,7 +329,7 @@ func (e *exporter) resolve(env *adt.Environment, r adt.Resolver) ast.Expr {
 		// comprehensions originate from a single source and do not need to be
 		// handled.
 		if env != nil { // for generated stuff
-			if v := env.Vertex; !v.IsDynamic {
+			if v := env.Vertex; v != nil && !v.IsDynamic {
 				if v = v.Lookup(x.Label); v != nil {
 					e.linkIdentifier(v, ident)
 				}

--- a/internal/core/export/testdata/main/issue2584.txtar
+++ b/internal/core/export/testdata/main/issue2584.txtar
@@ -1,0 +1,100 @@
+# issue #2584
+
+-- in.cue --
+F1: sub1: sub2: L
+F2: {
+	(string): _
+	L
+}
+D: {}
+let L = D
+-- out/default --
+-- out/definition --
+
+let L = D
+F1: {
+	sub1: {
+		sub2: L
+	}
+}
+F2: {
+	(string): _
+	L
+}
+D: {}
+-- out/doc --
+[]
+[F1]
+[F1 sub1]
+[F1 sub1 sub2]
+[F2]
+[F2 _]
+[D]
+[L]
+-- out/value --
+== Simplified
+{
+	let L = D
+	F1: {
+		sub1: {
+			sub2: {}
+		}
+	}
+	F2: {
+		(string): _
+		L
+	}
+	D: {}
+}
+== Raw
+{
+	let L = D
+	F1: {
+		sub1: {
+			sub2: {}
+		}
+	}
+	F2: {
+		(string): _
+		L
+	}
+	D: {}
+}
+== Final
+{
+	F1: {
+		sub1: {
+			sub2: {}
+		}
+	}
+	F2: _|_ // F2: invalid non-ground value string (must be concrete string)
+	D: {}
+}
+== All
+{
+	let L = D
+	F1: {
+		sub1: {
+			sub2: {}
+		}
+	}
+	F2: {
+		(string): _
+		L
+	}
+	D: {}
+}
+== Eval
+{
+	let L = D
+	F1: {
+		sub1: {
+			sub2: {}
+		}
+	}
+	F2: {
+		(string): _
+		L
+	}
+	D: {}
+}


### PR DESCRIPTION
Before the fix, issue2584.txtar fails with a panic due to accessing a nil pointer. The fix prevents accessing the offending pointer.
After the fix, issue2584.txtar passes.

modified:   internal/core/export/adt.go
new file:   internal/core/export/testdata/main/issue2584.txtar

Fixes #12345