### PR TITLE
cue/cmd: Prevent exec.Run fatal errors for non-zero exit codes

### DIFF
--- a/cmd/cue/cmd/testdata/script/cmd_execerr.txtar
+++ b/cmd/cue/cmd/testdata/script/cmd_execerr.txtar
@@ -1,0 +1,56 @@
+! exec cue cmd cannotFail
+cmp stderr cannotFail-stderr.golden
+
+exec cue cmd canFail
+cmp stdout canFail-stdout.golden
+
+-- cue.mod/module.cue --
+module: "example.com"
+
+-- cannotFail-stderr.golden --
+task failed: command "false" failed: exit status 1
+-- canFail-stdout.golden --
+errExit:
+success=false
+hasStderr=false
+
+errNotFound:
+success=false
+hasStderr=true
+-- foo_tool.cue --
+package foo
+
+import (
+	"tool/cli"
+	"tool/exec"
+)
+
+command: cannotFail: {
+	one: exec.Run & {
+		cmd: ["false"]
+	}
+}
+
+command: canFail: {
+	errExit: exec.Run & {
+		cmd: ["false"]
+		stderr: string
+		mustSucceed: false
+	}
+	errNotFound: exec.Run & {
+		cmd: ["program-does-not-exist"]
+		stderr: string
+		mustSucceed: false
+	}
+	second: cli.Print & {
+		text: """
+			errExit:
+			success=\(errExit.success)
+			hasStderr=\(errExit.stderr != "")
+
+			errNotFound:
+			success=\(errNotFound.success)
+			hasStderr=\(errNotFound.stderr != "")
+			"""
+	}
+}

--- a/pkg/tool/exec/exec.cue
+++ b/pkg/tool/exec/exec.cue
@@ -48,4 +48,8 @@ Run: {
 	// code or false otherwise. The user can explicitly specify the value
 	// force a fatal error if the desired success code is not reached.
 	success: bool
+
+	// mustSucceed indicates whether a command must succeed, in which case success==false results in a fatal error.
+	// This option is enabled by default, but may be disabled to control what is done when a command execution fails.
+	mustSucceed: bool | *true
 }

--- a/pkg/tool/exec/pkg.go
+++ b/pkg/tool/exec/pkg.go
@@ -38,6 +38,10 @@
 //		// code or false otherwise. The user can explicitly specify the value
 //		// force a fatal error if the desired success code is not reached.
 //		success: bool
+//
+//		// mustSucceed indicates whether a command must succeed, in which case success==false results in a fatal error.
+//		// This option is enabled by default, but may be disabled to control what is done when a command execution fails.
+//		mustSucceed: bool | *true
 //	}
 package exec
 
@@ -62,10 +66,11 @@ var p = &pkg.Package{
 		env: {
 			[string]: string | [...=~"="]
 		}
-		stdout:  *null | string | bytes
-		stderr:  *null | string | bytes
-		stdin:   *null | string | bytes
-		success: bool
+		stdout:      *null | string | bytes
+		stderr:      *null | string | bytes
+		stdin:       *null | string | bytes
+		success:     bool
+		mustSucceed: bool | *true
 	}
 }`,
 }

--- a/tools/flow/testdata/template.txtar
+++ b/tools/flow/testdata/template.txtar
@@ -48,14 +48,14 @@ graph TD
 }
 -- out/run/t1/stats --
 Leaks:  0
-Freed:  42
-Reused: 35
+Freed:  45
+Reused: 38
 Allocs: 7
 Retain: 0
 
-Unifications: 25
-Conjuncts:    65
-Disjuncts:    42
+Unifications: 26
+Conjuncts:    68
+Disjuncts:    45
 -- out/run/t2 --
 graph TD
   t0("root.get [Terminated]")
@@ -67,10 +67,11 @@ graph TD
 	$id: "tool/exec.Run"
 	cmd: "go run cuelang.org/go/cmd/cue import -f -p json -l #Workflow: jsonschema: - --outfile pkg/github.com/SchemaStore/schemastore/src/schemas/json/github-workflow.cue"
 	env: {}
-	stdout:  "foo"
-	stderr:  null
-	stdin:   (*null | string | bytes) & GET.response.body
-	success: bool
+	stdout:      "foo"
+	stderr:      null
+	stdin:       (*null | string | bytes) & GET.response.body
+	success:     bool
+	mustSucceed: true
 
 	//cue:path: root.get
 	let GET = {
@@ -90,24 +91,24 @@ graph TD
 }
 -- out/run/t2/stats --
 Leaks:  0
-Freed:  42
-Reused: 42
+Freed:  45
+Reused: 45
 Allocs: 0
 Retain: 0
 
-Unifications: 25
-Conjuncts:    69
-Disjuncts:    42
+Unifications: 26
+Conjuncts:    72
+Disjuncts:    45
 -- out/run/stats/totals --
 Leaks:  0
-Freed:  84
-Reused: 77
+Freed:  90
+Reused: 83
 Allocs: 7
 Retain: 0
 
-Unifications: 50
-Conjuncts:    134
-Disjuncts:    84
+Unifications: 52
+Conjuncts:    140
+Disjuncts:    90
 -- out/run/t3 --
 graph TD
   t0("root.get [Terminated]")


### PR DESCRIPTION
This updates the logic in exec.Run to not return an error if a command returns a non-zero exit status. As a result, the success field can be used to determine if a command succeeded or failed.

Any errors that aren't related to the command failing to run or not completing successfully are still returned.

Fixes #2632