### PR TITLE
fix(cmd/cue): ensure package exists before extracting

### DIFF
--- a/cmd/cue/cmd/get_go.go
+++ b/cmd/cue/cmd/get_go.go
@@ -549,9 +549,10 @@ func (e *extractor) extractPkg(root string, p *packages.Package) error {
 	for path := range e.usedPkgs {
 		if !e.done[path] {
 			e.done[path] = true
-			p := p.Imports[path]
-			if err := e.extractPkg(root, p); err != nil {
-				return err
+			if p, ok := p.Imports[path]; ok {
+				if err := e.extractPkg(root, p); err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #2715.

The example in the issue failed when calling `e.extractPkg` with a nil package. This should fix it.