### PR TITLE
cmd/cue: fix how to trim prefix

### DIFF
--- a/cmd/cue/cmd/script_test.go
+++ b/cmd/cue/cmd/script_test.go
@@ -267,9 +267,7 @@ func TestX(t *testing.T) {
 	for s := bufio.NewScanner(bytes.NewReader(a.Comment)); s.Scan(); {
 		cmd := s.Text()
 		cmd = strings.TrimLeft(cmd, "! ")
-		if strings.HasPrefix(cmd, "exec ") {
-			cmd = cmd[len("exec "):]
-		}
+		cmd = strings.TrimPrefix(cmd, "exec ")
 		if !strings.HasPrefix(cmd, "cue ") {
 			continue
 		}


### PR DESCRIPTION
I modified trim process in test to be clearer.