### PR TITLE
cmd/cue: fix help cmd incorrect behavior

### DIFF
--- a/cmd/cue/cmd/help.go
+++ b/cmd/cue/cmd/help.go
@@ -21,6 +21,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var osExit = os.Exit
+
 // TODO: intersperse the examples at the end of the texts in the
 // body of text to make things more concrete for the user early on?
 // The current approach works will if users just print the text without
@@ -61,7 +63,7 @@ Simply type ` + c.Name() + ` help [path to command] for full details.`,
 			// If rests are not empty, args are invalid.
 			if cmd == nil || e != nil || len(rests) != 0 {
 				c.PrintErrf("Unknown help command: %#q\n", strings.Join(args, " "))
-				os.Exit(1)
+				osExit(1)
 			}
 			cobra.CheckErr(cmd.Help())
 		},

--- a/cmd/cue/cmd/root_test.go
+++ b/cmd/cue/cmd/root_test.go
@@ -59,4 +59,25 @@ func TestHelp(t *testing.T) {
 	if err := run("eval", "--help"); err != nil {
 		t.Error("help command failed unexpectedly")
 	}
+
+	// os.Exit(1) is expected
+	testOsExit(t, 1, []string{"help", "foo"}, run)
+
+	testOsExit(t, 1, []string{"help", "cmd", "foo"}, run)
+}
+
+// testOsExit tests that os.Exit is called with the given code when running f.
+func testOsExit(t *testing.T, code int, args []string, f func(args ...string) error) {
+	t.Helper()
+	oldExit := osExit
+	defer func() { osExit = oldExit }()
+	var status int
+	exit := func(code int) {
+		status = code
+	}
+	osExit = exit
+	f(args...)
+	if status != code {
+		t.Errorf("os.Exit(%d) not called", code)
+	}
 }


### PR DESCRIPTION
This fixes the issue of incorrect behavior when requesting help for an unknown command in the CUE CLI.

1. Modified the `newHelpCmd` function to handle unknown commands correctly.
2. When an unknown `cue help`  commands are entered, an error message is displayed and the program exits with a non-zero status code.
3. This ensures that the CLI behaves as expected and provides useful feedback to the user when an unknown command is entered.

 Fixes #2560