### PR TITLE
pkg/tool/exec: handle default value references in exec.Run environment variables

### DIFF
--- a/cmd/cue/cmd/testdata/script/cmd_execenv.txtar
+++ b/cmd/cue/cmd/testdata/script/cmd_execenv.txtar
@@ -1,0 +1,34 @@
+exec cue cmd execEnv
+cmp stdout stdout.golden
+
+-- cue.mod/module.cue --
+module: "example.com"
+
+-- stdout.golden --
+usesDefaultsStruct: hello from John Doe
+
+-- foo_tool.cue --
+package foo
+
+import (
+	"tool/cli"
+	"tool/exec"
+)
+
+#message: *"hello" | string
+
+command: execEnv: {
+    usesDefaultsStruct: exec.Run & {
+        cmd: ["sh", "-c", "echo $MESSAGE from $SENDER"]
+        stdout: *"" | string
+        env: {
+            MESSAGE: #message
+            SENDER: *"John Doe" | string
+        }
+    }
+    result: cli.Print & {
+        text: """
+        usesDefaultsStruct: \(usesDefaultsStruct.stdout)
+        """
+    }
+}

--- a/pkg/tool/exec/exec.go
+++ b/pkg/tool/exec/exec.go
@@ -152,13 +152,14 @@ func mkCommand(ctx *task.Context) (c *exec.Cmd, doc string, err error) {
 
 	cmd := exec.CommandContext(ctx.Context, bin, args...)
 
-	cmd.Dir, _ = ctx.Obj.Lookup("dir").String()
+	cmd.Dir, _ = ctx.Obj.LookupPath(cue.ParsePath("dir")).String()
 
-	env := ctx.Obj.Lookup("env")
+	env := ctx.Obj.LookupPath(cue.ParsePath("env"))
 
 	// List case.
 	for iter, _ := env.List(); iter.Next(); {
-		str, err := iter.Value().String()
+		v, _ := iter.Value().Default()
+		str, err := v.String()
 		if err != nil {
 			return nil, "", errors.Wrapf(err, v.Pos(),
 				"invalid environment variable value %q", v)
@@ -167,9 +168,9 @@ func mkCommand(ctx *task.Context) (c *exec.Cmd, doc string, err error) {
 	}
 
 	// Struct case.
-	for iter, _ := ctx.Obj.Lookup("env").Fields(); iter.Next(); {
+	for iter, _ := env.Fields(); iter.Next(); {
 		label := iter.Label()
-		v := iter.Value()
+		v, _ := iter.Value().Default()
 		var str string
 		switch v.Kind() {
 		case cue.StringKind:


### PR DESCRIPTION
Currently, environment variables used in exec.Run which contain references to default values results in an error when evaluating.

This fixes the handling of default values in exec.Run to ensure that environment variables which reference them are populated correctly.

Fixes #2572.