### PR TITLE
pkg/text/template: Add FuncMap support in text/templates

### DIFF
--- a/pkg/text/template/manual.go
+++ b/pkg/text/template/manual.go
@@ -41,7 +41,9 @@ func AddFuncMap(funcMap FuncMap) {
 
 // Execute executes a Go-style template.
 func Execute(templ string, data cue.Value) (string, error) {
+	muFM.Lock()
 	t, err := template.New("").Funcs(fm).Parse(templ)
+	muFM.Unlock()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/text/template/manual.go
+++ b/pkg/text/template/manual.go
@@ -15,15 +15,33 @@
 package template
 
 import (
+	"maps"
 	"strings"
+	"sync"
 	"text/template"
 
 	"cuelang.org/go/cue"
 )
 
+type FuncMap template.FuncMap
+
+var (
+	fm   = make(template.FuncMap)
+	muFM = sync.Mutex{}
+)
+
+// AddFuncMap copies funcMap provided by the user to global map.
+// If AddFuncMap is called multiple times with a key already present in global map,
+// the value in the global map will be overwritten by the latest value associated
+func AddFuncMap(funcMap FuncMap) {
+	muFM.Lock()
+	defer muFM.Unlock()
+	maps.Copy(fm, funcMap)
+}
+
 // Execute executes a Go-style template.
 func Execute(templ string, data cue.Value) (string, error) {
-	t, err := template.New("").Parse(templ)
+	t, err := template.New("").Funcs(fm).Parse(templ)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
* This attempts to _partially_ resolve: https://github.com/cue-lang/cue/discussions/2498 
* Does not change CUE API for text/templates
* This only enables users who use Go API, to create user-defined Go functions via text/template
* Since text/template only returns `string`, users will need to use `strconv` library for other formats.

### Usage

example.cue
```cue
package gen

import (
	"text/template"
	"strconv"
)

isadult: bool

#person: {
	Name: "John"
}

#templatetext: "{{ .Name }} is of age {{ GetAge .Name }}."
#checkadult:   "{{ IsAdult .Name }}"

message: template.Execute(#templatetext, #person)
isadult: strconv.ParseBool(template.Execute(#checkadult, #person))
```

main.go
```go
package main

import (
	"fmt"
	"log"

	"cuelang.org/go/cue/cuecontext"
	"cuelang.org/go/cue/load"
	"cuelang.org/go/encoding/yaml"
	"cuelang.org/go/pkg/text/template"
)

var person = map[string]int{
	"John": 25,
	"Jane": 30,
}

func GetAge(name string) int {
	return person[name]
}

func main() {
	ctx := cuecontext.New()
	template.AddFuncMap(template.FuncMap{
		"GetAge": GetAge,
		"IsAdult": func(name string) bool {
			if GetAge(name) > 18 {
				return true
			}
			return false
		},
	})
	// Load the CUE file
	instances := load.Instances([]string{"./example.cue"}, nil)
	v := ctx.BuildInstance(instances[0])
	if v.Err() != nil {
		log.Fatalf("Failed to load CUE file: %v", v.Err())
	}

	// Export as YAML
	data, err := yaml.Encode(v)
	if err != nil {
		log.Fatalf("Failed to marshal as YAML: %v", err)
	}

	// Output YAML to stdout
	fmt.Println(string(data))
}
```