### PR TITLE
fix path.Match, missing param when registering

### DIFF
--- a/pkg/path/pkg.go
+++ b/pkg/path/pkg.go
@@ -123,6 +123,7 @@ var p = &pkg.Package{
 		Name: "Match",
 		Params: []pkg.Param{
 			{Kind: adt.StringKind},
+			{Kind: adt.StringKind},
 			{Kind: adt.StringKind, Value: unixDefault},
 		},
 		Result: adt.BoolKind,


### PR DESCRIPTION
Feel free to make this one-line change on your own clone if it will be much faster and make v0.9

---

Fixes input parameter handling

https://cuelang.org/play/?id=pJ-fBYTb409#w=function&i=cue&f=eval&o=cue

```
import "path"

a: path.IsAbs("/foo")
a: path.IsAbs("/foo", "unix")
b: path.Split("/a/b/c")
b: path.Split("/a/b/c", "unix")
c: path.Rel("/a/b/c", "/a/b")
d: path.Match("/a/b/c", "/a")

// Expected way to use
// e1: too many arguments in call to path.Match (have 3, want 2)
// e1: path.Match("foo.cue", "*.cue", "unix")

// so remove os...?
// cannot use "*.cue" as *"unix" | "windows" | "plan9" | "aix" | "android" | ...
// e2: path.Match("foo.cue", "*.cue")

// is this a constraint only?
// error in call to path.Match: runtime error: index out of range [2] with length 2
// e3: "foo.cue" & path.Match("*.cue", "unix")
```