### PR TITLE
cmd/cue/cmd: add go tag for or expressions

### DIFF
--- a/cmd/cue/cmd/get_go.go
+++ b/cmd/cue/cmd/get_go.go
@@ -1343,6 +1343,14 @@ func (e *extractor) addFields(x *types.Struct, st *cueast.StructLit) {
 			field.Value = cueast.NewBinExpr(cuetoken.AND, field.Value, expr)
 		}
 
+		if s := reflect.StructTag(tag).Get("cue_or"); s != "" {
+			expr, err := parser.ParseExpr("get go", s)
+			if err != nil {
+				e.logf("error parsing struct tag %q:", s, err)
+			}
+			field.Value = cueast.NewBinExpr(cuetoken.OR, field.Value, expr)
+		}
+
 		// Add field tag to convert back to Go.
 		typeName := f.Type().String()
 		// simplify type names:


### PR DESCRIPTION
This adds a new Go tag which allows the use of OR expressions when generating Cue based on Go.

I'm aware that this change might not be the desired way of resolving the lack of having OR expressions available based on tags in cue tags in Go structs.
If that is the case, take this PR as more of a discussion on how to properly implement this.

I've got the need for this feature, as it'll allow me and my team to generate CUE schemas purely based on our Go structs with the desired defaults that we intend to have on those fields.
A more concrete example is the following:

```Go
type Module struct {
	Org string `json:"org,omitempty" yaml:"org,omitempty" cue_or:"*\"org_name\""`
}
```

```CUE
#Module: {
	org?: string | *"org_name" @go(Org)
}
```

Where as the only tag available today `cue` only supports `AND` expressions.