### PR TITLE
Introducing CUE Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 [![Go 1.22+](https://img.shields.io/badge/go-1.22-9cf.svg)](https://golang.org/dl/)
 [![platforms](https://img.shields.io/badge/platforms-linux|windows|macos-inactive.svg)]()
 [![Docker Image](https://img.shields.io/docker/v/cuelang/cue?sort=semver&label=docker)](https://hub.docker.com/r/cuelang/cue)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20CUE%20Guru-006BFF)](https://gurubase.io/g/cue)
 
 # The CUE Data Constraint Language
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [CUE Guru](https://gurubase.io/g/cue) to Gurubase. CUE Guru uses the data from this repo and data from the [docs](https://cuelang.org/docs/) to answer questions by leveraging the LLM.

In this PR, I showcased the "CUE Guru", which highlights that CUE now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable CUE Guru in Gurubase, just let me know that's totally fine.
