### PR TITLE
internal/mod/modload: preserve custom struct in module when tidying requirements

### DIFF
--- a/internal/mod/modload/testdata/tidy/preserve-custom.txtar
+++ b/internal/mod/modload/testdata/tidy/preserve-custom.txtar
@@ -1,0 +1,20 @@
+-- cue.mod/module.cue --
+module: "cue.example"
+language: {
+	version: "v0.12.0"
+}
+custom: {
+	"example.com/mycoolmodule": {
+		test: "data"
+	}
+}
+-- want --
+module: "cue.example"
+language: {
+	version: "v0.12.0"
+}
+custom: {
+	"example.com/mycoolmodule": {
+		test: "data"
+	}
+}

--- a/internal/mod/modload/tidy.go
+++ b/internal/mod/modload/tidy.go
@@ -156,6 +156,7 @@ func modfileFromRequirements(old *modfile.File, rs *modrequirements.Requirements
 		Language: old.Language,
 		Deps:     make(map[string]*modfile.Dep),
 		Source:   old.Source,
+		Custom:   old.Custom,
 	}
 	defaults := rs.DefaultMajorVersions()
 	for _, v := range rs.RootModules() {


### PR DESCRIPTION
This updates modfileFromRequirements to copy the custom struct from the original modfile to the tidied one.

Fixes #3876