### PR TITLE
internal/encoding/gotypes: generate unquoted json tag for fields with quoted name

### DIFF
--- a/cmd/cue/cmd/testdata/script/exp_gengotypes.txtar
+++ b/cmd/cue/cmd/testdata/script/exp_gengotypes.txtar
@@ -186,10 +186,10 @@ fail.both."42_LinkedList".types.LinkedList.next: conflicting values "x" and {ite
     ./root/types.cue:43:14
 fail.both.notList: conflicting values [1,2,3] and {embedded2?:int} (mismatched types list and struct):
     ./cuetest/all.cue:5:24
-    ./root/root.cue:95:2
+    ./root/root.cue:96:2
 fail.both.notString: conflicting values "not_a_struct" and {embedded2?:int} (mismatched types string and struct):
     ./cuetest/all.cue:4:24
-    ./root/root.cue:95:2
+    ./root/root.cue:96:2
 fail.cue."11_Int8".types.Int8: invalid value 99999 (out of bound <=127):
     ./cuetest/all.cue:61:30
 fail.cue."12_Int8".types.Int8: invalid value -99999 (out of bound >=-128):
@@ -435,6 +435,7 @@ _#overridenNeverGenerate: string
 
 	mustEqual1?: int
 	mustEqual2?: mustEqual1
+	"quoted-field"?: string @go(QuotedField)
 }
 
 // Actually, this field needed even more documentation.
@@ -646,6 +647,8 @@ type Root struct {
 		Regular int64 `json:"regular"`
 
 		Required int64 `json:"required,omitempty"`
+
+		QuotedField string `json:"quoted-field"`
 
 		// Optional types are represented as *T in Go if they are structs.
 		Optional int64 `json:"optional,omitempty"`

--- a/internal/encoding/gotypes/generate.go
+++ b/internal/encoding/gotypes/generate.go
@@ -265,6 +265,9 @@ func (g *generator) emitType(val cue.Value, optional bool) error {
 				continue
 			}
 			cueName := sel.String()
+			if sel.IsString() {
+				cueName = sel.Unquoted()
+			}
 			cueName = strings.TrimRight(cueName, "?!")
 			g.emitDocs(cueName, val.Doc())
 			// TODO: should we ensure that optional fields are always nilable in Go?


### PR DESCRIPTION
This change updates the behavior of the generator to use the unquoted field name of fields with string names.

Closes #3882