### PR TITLE
internal/encoding/yaml: encode YAML anchors as CUE definitions

### DIFF
--- a/internal/encoding/yaml/decode_test.go
+++ b/internal/encoding/yaml/decode_test.go
@@ -475,8 +475,8 @@ Null: 1
 	{
 		"a: &x 1\nb: &y 2\nc: *x\nd: *y\n",
 		`#x: 1
-#y: 2
 a:  #x
+#y: 2
 b:  #y
 c:  #x
 d:  #y`,
@@ -820,9 +820,9 @@ a:
 	{
 		"First occurrence: &anchor Foo\nSecond occurrence: *anchor\nOverride anchor: &anchor Bar\nReuse anchor: *anchor\n",
 		`#anchor:             "Foo"
-#anchor_2:           "Bar"
 "First occurrence":  #anchor
 "Second occurrence": #anchor
+#anchor_2:           "Bar"
 "Override anchor":   #anchor_2
 "Reuse anchor":      #anchor_2`,
 	},

--- a/internal/encoding/yaml/testdata/merge.out
+++ b/internal/encoding/yaml/testdata/merge.out
@@ -1,15 +1,17 @@
+#CENTER: {x: 1, y: 2}
+#LEFT: {x: 0, y: 2}
+#BIG: {r: 10}
+#SMALL: {r: 1}
+
 // From http://yaml.org/type/merge.html
 // Test
 anchors: {
-	list: [{
-		x: 1, y: 2
-	}, {
-		x: 0, y: 2
-	}, {
-		r: 10
-	}, {
-		r: 1
-	}]
+	list: [
+		#CENTER,
+		#LEFT,
+		#BIG,
+		#SMALL,
+	]
 }
 
 // All the following maps are equal:


### PR DESCRIPTION
Fixes #3818

There's one small issue open to handle. Tests are currently failing with:

```
--- FAIL: TestUnmarshalErrors (0.00s)
    --- FAIL: TestUnmarshalErrors/test_7:_"a:_&a\n__b:_*a\n" (0.00s)
        decode_test.go:971:   yaml:
            a: &a
              b: *a
        decode_test.go:977: got <nil>; want test.yaml:2: anchor "a" value contains itself; (value #a: {
                b: #a
            }
            a: #a)
--- FAIL: TestDecoderErrors (0.00s)
    --- FAIL: TestDecoderErrors/test_7:_"a:_&a\n__b:_*a\n" (0.00s)
        decode_test.go:986:   yaml:
            a: &a
              b: *a
        decode_test.go:988: got <nil>; want test.yaml:2: anchor "a" value contains itself
```

I could change the code to match the old behavior of rejecting such YAML documents, since the resulting CUE document is invalid.
However, I think the original reason we error out for such document was that it would lead to endless recursion in the parser. This is no longer the case, so I'm debating whether the correct fix would be to error out, or change the test.