### PR TITLE
yaml/validate: Improve error reporting

### DIFF
--- a/cue/testdata/cycle/builtins.txtar
+++ b/cue/testdata/cycle/builtins.txtar
@@ -796,24 +796,24 @@ Result:
       }
     }
     yamlVal: (_|_){
-      // [eval]
+      // [structural cycle]
       t1: (_|_){
-        // [eval]
+        // [structural cycle]
         x: (_|_){
-          // [eval]
+          // [structural cycle]
           y: (_|_){
-            // [eval] selfCycle.yamlVal.t1.x.y: invalid value "{}" (does not satisfy encoding/yaml.Validate): error in call to encoding/yaml.Validate: structural cycle:
+            // [structural cycle] selfCycle.yamlVal.t1.x.y: invalid value "{}" (does not satisfy encoding/yaml.Validate): error in call to encoding/yaml.Validate: structural cycle:
             //     ./yamlcycle.cue:24:8
             //     ./yamlcycle.cue:25:8
           }
         }
       }
       t2: (_|_){
-        // [eval]
+        // [structural cycle]
         x: (_|_){
-          // [eval]
+          // [structural cycle]
           y: (_|_){
-            // [eval] selfCycle.yamlVal.t2.x.y: invalid value "{}" (does not satisfy encoding/yaml.Validate): error in call to encoding/yaml.Validate: structural cycle:
+            // [structural cycle] selfCycle.yamlVal.t2.x.y: invalid value "{}" (does not satisfy encoding/yaml.Validate): error in call to encoding/yaml.Validate: structural cycle:
             //     ./yamlcycle.cue:30:8
             //     ./yamlcycle.cue:31:8
             //     ./yamlcycle.cue:32:8
@@ -823,25 +823,25 @@ Result:
       }
     }
     yamlFun: (_|_){
-      // [eval]
+      // [structural cycle]
       t1: (struct){
         x: (struct){
           y?: (bool){ true }
         }
       }
       t2: (_|_){
-        // [eval]
+        // [structural cycle]
         z: (_|_){
-          // [eval]
+          // [structural cycle]
           y: (_|_){
-            // [eval] selfCycle.yamlFun.t2.z.y: error in call to encoding/yaml.Validate: structural cycle:
+            // [structural cycle] selfCycle.yamlFun.t2.z.y: error in call to encoding/yaml.Validate: structural cycle:
             //     ./yamlcycle.cue:41:8
           }
         }
         x: (_|_){
-          // [eval]
+          // [structural cycle]
           y: (_|_){
-            // [eval] selfCycle.yamlFun.t2.x.y: error in call to encoding/yaml.Validate: structural cycle:
+            // [structural cycle] selfCycle.yamlFun.t2.x.y: error in call to encoding/yaml.Validate: structural cycle:
             //     ./yamlcycle.cue:41:8
           }
         }
@@ -1178,31 +1178,31 @@ diff old new
      yamlVal: (_|_){
 @@ -466,25 +494,33 @@
        t1: (_|_){
-         // [eval]
+         // [structural cycle]
          x: (_|_){
--          // [eval] selfCycle.yamlVal.t1.x.y.y: structural cycle:
+-          // [structural cycle] selfCycle.yamlVal.t1.x.y.y: structural cycle:
 -          //     ./yamlcycle.cue:24:22
 -        }
 -      }
 -      t2: (_|_){
--        // [eval]
+-        // [structural cycle]
 -        x: (_|_){
--          // [eval] selfCycle.yamlVal.t2.x.y.y: structural cycle:
+-          // [structural cycle] selfCycle.yamlVal.t2.x.y.y: structural cycle:
 -          //     ./yamlcycle.cue:32:22
-+          // [eval]
++          // [structural cycle]
 +          y: (_|_){
-+            // [eval] selfCycle.yamlVal.t1.x.y: invalid value "{}" (does not satisfy encoding/yaml.Validate): error in call to encoding/yaml.Validate: structural cycle:
++            // [structural cycle] selfCycle.yamlVal.t1.x.y: invalid value "{}" (does not satisfy encoding/yaml.Validate): error in call to encoding/yaml.Validate: structural cycle:
 +            //     ./yamlcycle.cue:24:8
 +            //     ./yamlcycle.cue:25:8
 +          }
 +        }
 +      }
 +      t2: (_|_){
-+        // [eval]
++        // [structural cycle]
 +        x: (_|_){
-+          // [eval]
++          // [structural cycle]
 +          y: (_|_){
-+            // [eval] selfCycle.yamlVal.t2.x.y: invalid value "{}" (does not satisfy encoding/yaml.Validate): error in call to encoding/yaml.Validate: structural cycle:
++            // [structural cycle] selfCycle.yamlVal.t2.x.y: invalid value "{}" (does not satisfy encoding/yaml.Validate): error in call to encoding/yaml.Validate: structural cycle:
 +            //     ./yamlcycle.cue:30:8
 +            //     ./yamlcycle.cue:31:8
 +            //     ./yamlcycle.cue:32:8
@@ -1212,7 +1212,7 @@ diff old new
        }
      }
      yamlFun: (_|_){
-       // [eval]
+       // [structural cycle]
 -      t1: (_|_){
 -        // [structural cycle]
 -        x: (_|_){
@@ -1226,23 +1226,23 @@ diff old new
        t2: (_|_){
 @@ -492,13 +528,16 @@
          z: (_|_){
-           // [eval]
+           // [structural cycle]
            y: (_|_){
--            // [eval] selfCycle.yamlFun.t2.x.y.y: structural cycle:
+-            // [structural cycle] selfCycle.yamlFun.t2.x.y.y: structural cycle:
 -            //     ./yamlcycle.cue:41:28
 -          }
 -        }
 -        x: (_|_){
--          // [eval] selfCycle.yamlFun.t2.x.y.y: structural cycle:
+-          // [structural cycle] selfCycle.yamlFun.t2.x.y.y: structural cycle:
 -          //     ./yamlcycle.cue:41:28
-+            // [eval] selfCycle.yamlFun.t2.z.y: error in call to encoding/yaml.Validate: structural cycle:
++            // [structural cycle] selfCycle.yamlFun.t2.z.y: error in call to encoding/yaml.Validate: structural cycle:
 +            //     ./yamlcycle.cue:41:8
 +          }
 +        }
 +        x: (_|_){
-+          // [eval]
++          // [structural cycle]
 +          y: (_|_){
-+            // [eval] selfCycle.yamlFun.t2.x.y: error in call to encoding/yaml.Validate: structural cycle:
++            // [structural cycle] selfCycle.yamlFun.t2.x.y: error in call to encoding/yaml.Validate: structural cycle:
 +            //     ./yamlcycle.cue:41:8
 +          }
          }
@@ -1730,24 +1730,24 @@ Result:
       }
     }
     yamlVal: (_|_){
-      // [eval]
+      // [structural cycle]
       t1: (_|_){
-        // [eval]
+        // [structural cycle]
         x: (_|_){
-          // [eval] selfCycle.yamlVal.t1.x.y.y: structural cycle:
+          // [structural cycle] selfCycle.yamlVal.t1.x.y.y: structural cycle:
           //     ./yamlcycle.cue:24:22
         }
       }
       t2: (_|_){
-        // [eval]
+        // [structural cycle]
         x: (_|_){
-          // [eval] selfCycle.yamlVal.t2.x.y.y: structural cycle:
+          // [structural cycle] selfCycle.yamlVal.t2.x.y.y: structural cycle:
           //     ./yamlcycle.cue:32:22
         }
       }
     }
     yamlFun: (_|_){
-      // [eval]
+      // [structural cycle]
       t1: (_|_){
         // [structural cycle]
         x: (_|_){
@@ -1756,16 +1756,16 @@ Result:
         }
       }
       t2: (_|_){
-        // [eval]
+        // [structural cycle]
         z: (_|_){
-          // [eval]
+          // [structural cycle]
           y: (_|_){
-            // [eval] selfCycle.yamlFun.t2.x.y.y: structural cycle:
+            // [structural cycle] selfCycle.yamlFun.t2.x.y.y: structural cycle:
             //     ./yamlcycle.cue:41:28
           }
         }
         x: (_|_){
-          // [eval] selfCycle.yamlFun.t2.x.y.y: structural cycle:
+          // [structural cycle] selfCycle.yamlFun.t2.x.y.y: structural cycle:
           //     ./yamlcycle.cue:41:28
         }
       }

--- a/internal/encoding/yaml/validate.go
+++ b/internal/encoding/yaml/validate.go
@@ -57,10 +57,10 @@ func Validate(c *adt.OpContext, b []byte, v cue.Value) (bool, error) {
 		// 	return false, err
 		// }
 		vx := adt.Unify(c, value.Vertex(x), value.Vertex(v))
+		x = value.Make(c, vx)
 		if err := x.Err(); err != nil {
 			return false, err
 		}
-		x = value.Make(c, vx)
 
 		if err := x.Validate(cue.Concrete(true)); err != nil {
 			// Strip error codes: incomplete errors are terminal in this case.

--- a/pkg/encoding/json/testdata/gen.txtar
+++ b/pkg/encoding/json/testdata/gen.txtar
@@ -14,6 +14,8 @@ validate: t2: schema: {a: <3}
 validate: disjunctionRequired: schema: {a!: int} | {b!: int}
 validate: disjunctionClosed: schema: close({a: int}) | close({b: int})
 
+validate: invalidDisjuntion: schema: {a: 1 | 2}
+
 // Issue #2395
 validate: enforceRequired: {
 	str: "{}"
@@ -96,14 +98,16 @@ unmarshalStream: {
 }
 -- out/json --
 Errors:
+validate.invalidDisjuntion.result: error in call to encoding/json.Validate: 2 errors in empty disjunction::
+    ./in.cue:6:10
 validate.t2.result: error in call to encoding/json.Validate: invalid value 10 (out of bound <3):
     ./in.cue:6:10
     ./in.cue:9:27
     json.Validate:1:6
 unmarshal.trailingInvalid.#result: error in call to encoding/json.Unmarshal: json: invalid JSON:
-    ./in.cue:47:11
+    ./in.cue:49:11
 unmarshal.trailingValid.#result: error in call to encoding/json.Unmarshal: json: invalid JSON:
-    ./in.cue:47:11
+    ./in.cue:49:11
 
 Result:
 import "encoding/json"
@@ -140,6 +144,13 @@ validate: {
 			b: int
 		}
 		result: true
+	}
+	invalidDisjuntion: {
+		str: *"{\"a\":10}" | string
+		schema: {
+			a: 1 | 2
+		}
+		result: _|_ // validate.invalidDisjuntion.result: error in call to encoding/json.Validate: validate.invalidDisjuntion.result.a: 2 errors in empty disjunction: (and 2 more errors)
 	}
 
 	// Issue #2395

--- a/pkg/encoding/yaml/testdata/validate.txtar
+++ b/pkg/encoding/yaml/testdata/validate.txtar
@@ -30,6 +30,8 @@ validate: #test & {
 validatePartial: #test & {
 	fn: yaml.ValidatePartial
 }
+
+invalidDisjuntion: yaml.Validate("a: 3", {a: 1 | 2})
 -- diff/todo --
 missing position
 -- out/yaml --
@@ -48,6 +50,8 @@ validate.t1.ok1: invalid value "a: 2" (does not satisfy encoding/yaml.Validate):
     ./in.cue:17:11
 #test.t2.ok2: cannot call non-function fn (type _):
     ./in.cue:18:11
+invalidDisjuntion: error in call to encoding/yaml.Validate: 2 errors in empty disjunction::
+    ./in.cue:33:20
 
 Result:
 import "encoding/yaml"
@@ -115,3 +119,4 @@ validatePartial: {
 		ok2: "'foo'"
 	}
 }
+invalidDisjuntion: _|_ // invalidDisjuntion: error in call to encoding/yaml.Validate: invalidDisjuntion.a: 2 errors in empty disjunction:

--- a/pkg/encoding/yaml/testdata/validate.txtar
+++ b/pkg/encoding/yaml/testdata/validate.txtar
@@ -119,4 +119,4 @@ validatePartial: {
 		ok2: "'foo'"
 	}
 }
-invalidDisjuntion: _|_ // invalidDisjuntion: error in call to encoding/yaml.Validate: invalidDisjuntion.a: 2 errors in empty disjunction:
+invalidDisjuntion: _|_ // invalidDisjuntion: error in call to encoding/yaml.Validate: invalidDisjuntion.a: 2 errors in empty disjunction: (and 2 more errors)


### PR DESCRIPTION
This makes `yaml.Validate(data, schema)` work more similarly to what one would likely do manually (`schema.Unify(data).Validate()`).

Namely this improves error reporting.

Closes https://github.com/cue-lang/cue/issues/4002