### PR TITLE
cmd/cue/cmd: use ParseInt with 64 bit size in cmd_after testdata

### DIFF
--- a/cmd/cue/cmd/testdata/script/cmd_after.txtar
+++ b/cmd/cue/cmd/testdata/script/cmd_after.txtar
@@ -38,8 +38,8 @@ command: after: {
 	}
 	t3: cli.Print & {
 		text: strconv.FormatBool(
-			strconv.Atoi(strings.TrimSpace(group.t1.stdout)) <
-				strconv.Atoi(strings.TrimSpace(group.t2.stdout))
+			strconv.ParseInt(strings.TrimSpace(group.t1.stdout), 10, 64) <
+				strconv.ParseInt(strings.TrimSpace(group.t2.stdout), 10, 64)
 			)
 	}
 	t4: cli.Print & {


### PR DESCRIPTION
The current milliseconds since Epoch is out of bound for a 32-bit int (returned by `strconv.Atoi`), so return int64 explicitly by switching to `strconv.ParseInt`. This change allows the test case to run successfully on 32-bit platforms.

I applied the patch in https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/88353. It seems to fix our AlpineLinux 32-bit CI build.