### PR TITLE
encoding/toml: fix decoding subtable duplicate keys

### DIFF
--- a/encoding/toml/decode_test.go
+++ b/encoding/toml/decode_test.go
@@ -644,6 +644,42 @@ line two.\
 			]
 			`,
 	}, {
+		name: "ArrayTablesSubtableDuplicateKey",
+		input: `
+			[[foo]]
+			[foo.subtable]
+			name = "bar"
+			[[foo]]
+			[foo.subtable]
+			name = "bar"
+			`,
+		wantCUE: `
+			foo: [
+				{
+					subtable: {
+						name: "bar"
+					}
+				},
+				{
+					subtable: {
+						name: "bar"
+					}
+				}
+			]
+			`,
+	}, {
+		name: "ArrayTablesSubtableActualDuplicate",
+		input: `
+			[[foo]]
+			[foo.subtable]
+			name = "bar"
+			[foo.subtable]
+			`,
+		wantErr: `
+				duplicate key: foo.subtable:
+				    test.toml:4:2
+				`,
+	}, {
 		name: "ArrayTablesNested",
 		input: `
 			[[foo]]


### PR DESCRIPTION
Previously, subtables with duplicate keys fail to be decoded even though they represent valid TOML. Instead we should track seenTableKeys by the array index to ensure duplication is local to the given object

Fixes https://github.com/cue-lang/cue/issues/3609