### PR TITLE
encoding/protobuf/parse: fix crashing on builtin package imports

### DIFF
--- a/encoding/protobuf/parse.go
+++ b/encoding/protobuf/parse.go
@@ -313,14 +313,14 @@ func (p *protoConverter) doImport(v *proto.Import) error {
 		break
 	}
 
+	if !p.mapBuiltinPackage(v.Position, v.Filename, filename == "") {
+		return nil
+	}
+
 	if filename == "" {
 		err := errors.Newf(p.toCUEPos(v.Position), "could not find import %q", v.Filename)
 		p.state.addErr(err)
 		return err
-	}
-
-	if !p.mapBuiltinPackage(v.Position, v.Filename, filename == "") {
-		return nil
 	}
 
 	imp, err := p.state.parse(filename, nil)

--- a/encoding/protobuf/protobuf_test.go
+++ b/encoding/protobuf/protobuf_test.go
@@ -37,6 +37,7 @@ func TestExtractDefinitions(t *testing.T) {
 		"mixer/v1/attributes.proto",
 		"mixer/v1/config/client/client_config.proto",
 		"other/trailcomment.proto",
+		"other/builtinpkg.proto",
 	}
 	for _, file := range testCases {
 		t.Run(file, func(t *testing.T) {

--- a/encoding/protobuf/testdata/builtinpkg.proto.out.cue
+++ b/encoding/protobuf/testdata/builtinpkg.proto.out.cue
@@ -1,0 +1,7 @@
+package builtinpkg
+
+import "time"
+
+#DefaultPkgTestMsg: {
+	observedAt?: time.Time @protobuf(1,google.protobuf.Timestamp,name=observed_at)
+}

--- a/encoding/protobuf/testdata/istio.io/api/other/builtinpkg.proto
+++ b/encoding/protobuf/testdata/istio.io/api/other/builtinpkg.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package builtinpkg;
+
+import "google/protobuf/timestamp.proto";
+
+message DefaultPkgTestMsg {
+  google.protobuf.Timestamp observed_at = 1;
+}


### PR DESCRIPTION
This commit fixes an issue where importing

"google/protobuf/timestamp.proto" or other builtin packages causes

the go proto extractor to crash.

By checking if the import is a builtin package before failing.

Additionally, a test case is added to ensure that this behavior works

Resolves https://github.com/cue-lang/cue/issues/4033