### PR TITLE
encoding/protobuf/parse: fix failing to find explicit names in same package

### DIFF
--- a/encoding/protobuf/parse.go
+++ b/encoding/protobuf/parse.go
@@ -277,7 +277,11 @@ func (p *protoConverter) resolveTopScope(pos scanner.Position, name string, opti
 		if k == -1 {
 			i = len(name)
 		}
-		if m, ok := p.scope[0][name[:i]]; ok {
+		curName := name[:i]
+		if local, ok := strings.CutPrefix(curName, p.protoPkg+"."); ok {
+			curName = local
+		}
+		if m, ok := p.scope[0][curName]; ok {
 			if m.pkg != nil {
 				p.imported[m.pkg.qualifiedImportPath()] = true
 			}
@@ -292,6 +296,7 @@ func (p *protoConverter) resolveTopScope(pos scanner.Position, name string, opti
 			ast.SetPos(expr, p.toCUEPos(pos))
 			return expr
 		}
+
 	}
 	failf(pos, "name %q not found", name)
 	return nil

--- a/encoding/protobuf/protobuf_test.go
+++ b/encoding/protobuf/protobuf_test.go
@@ -37,6 +37,7 @@ func TestExtractDefinitions(t *testing.T) {
 		"mixer/v1/attributes.proto",
 		"mixer/v1/config/client/client_config.proto",
 		"other/trailcomment.proto",
+		"other/full_references.proto",
 	}
 	for _, file := range testCases {
 		t.Run(file, func(t *testing.T) {

--- a/encoding/protobuf/testdata/full_references.proto.out.cue
+++ b/encoding/protobuf/testdata/full_references.proto.out.cue
@@ -1,0 +1,13 @@
+package full_references
+
+#FullReferenceMsg: {
+	nestedMsg?: #FullReferenceNestedMsg @protobuf(1,istio.io.api.other.full_references.FullReferenceNestedMsg,name=nested_msg)
+}
+
+#FullReferenceNestedMsg: {
+
+	#FullReferenceDoubleNestedMsg: {
+		value?: string @protobuf(1,string)
+	}
+	nestedMsg?: #FullReferenceNestedMsg.#FullReferenceDoubleNestedMsg @protobuf(1,istio.io.api.other.full_references.FullReferenceNestedMsg.FullReferenceDoubleNestedMsg,name=nested_msg)
+}

--- a/encoding/protobuf/testdata/istio.io/api/other/full_references.proto
+++ b/encoding/protobuf/testdata/istio.io/api/other/full_references.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package istio.io.api.other.full_references;
+
+message FullReferenceMsg {
+  istio.io.api.other.full_references.FullReferenceNestedMsg nested_msg = 1;
+}
+
+message FullReferenceNestedMsg {
+  message FullReferenceDoubleNestedMsg {
+    string value = 1;
+  }
+
+  istio.io.api.other.full_references.FullReferenceNestedMsg.FullReferenceDoubleNestedMsg nested_msg = 1;
+}
+
+


### PR DESCRIPTION
This commit makes it so that fully qualified names

that are defined in the same file

are resolved properly.

It also adds tests to confirm that this behavior works

Resolves: https://github.com/cue-lang/cue/issues/4035