### PR TITLE
internal/core/runtime: replace slice with sync.Map

### DIFF
--- a/internal/core/runtime/index.go
+++ b/internal/core/runtime/index.go
@@ -61,7 +61,7 @@ func (r *Runtime) Label(s string, isIdent bool) adt.Feature {
 // TODO: move to Runtime as fields.
 var (
 	labelMap = map[string]int{}
-	labels   = make([]string, 0, 1000)
+	labels   sync.Map
 	mutex    sync.RWMutex
 )
 
@@ -83,15 +83,13 @@ func getKey(s string) int64 {
 	if ok {
 		return int64(p)
 	}
-	p = len(labels)
-	labels = append(labels, s)
+	p = len(labelMap)
+	labels.Store(p, s)
 	labelMap[s] = p
 	return int64(p)
 }
 
 func (x *index) IndexToString(i int64) string {
-	mutex.RLock()
-	s := labels[i]
-	mutex.RUnlock()
-	return s
+	s, _ := labels.Load(int(i))
+	return s.(string)
 }


### PR DESCRIPTION
We have a workload that makes many calls to cue.Value.Path(), which spends most of its time inside IndexToString's RWMutex.Rlock() call.

This change attempts to optimize that by replacing the `labels` slice with a `sync.Map`.

From `sync.Map`'s godoc:

> The Map type is optimized for two common use cases:
> (1) when the entry for a given key is only ever written once but read
> many times, as in caches that only grow, ...
> In these two cases, use of a Map may significantly reduce lock
> contention compared to a Go map paired with a separate Mutex or RWMutex.

I believe this maps exactly to what IndexToString is doing, and indeed we spend about 50% less time inside IndexToString after this change.