### PR TITLE
Return decl attrs from Value.Attribute and preserve embed YAML tags

### DIFF
--- a/cue/attribute.go
+++ b/cue/attribute.go
@@ -38,6 +38,13 @@ func (v Value) Attribute(key string) Attribute {
 		}
 		return newAttr(internal.FieldAttr, a)
 	}
+	for _, a := range export.ExtractDeclAttrs(v.v) {
+		k, _ := a.Split()
+		if key != k {
+			continue
+		}
+		return newAttr(internal.DeclAttr, a)
+	}
 
 	return nonExistAttr(key)
 }

--- a/internal/encoding/yaml/encode_test.go
+++ b/internal/encoding/yaml/encode_test.go
@@ -155,6 +155,14 @@ f4: {} # line 4
 # trail
 `,
 	}, {
+		name: "embed_binary",
+		in: `
+		{'\x80'}
+		`,
+		out: `
+!!binary gA==
+`,
+	}, {
 		// TODO: support this at some point
 		name: "anchors",
 		in: `
@@ -306,6 +314,19 @@ custom: !%3Ctag:example.com,2000:app/foo%3E value
 		`,
 		out: `
 item: !%3Chttps://example.com/schema/v1%3E value
+		`,
+	}, {
+		name: "yaml_tag_embed",
+		in: `
+		items: [
+			"first",
+			{"second", @yaml(,tag="!Env")},
+		] @yaml(,tag="!Format")
+		`,
+		out: `
+items: !Format
+  - first
+  - !Env second
 		`,
 	}, {
 		name: "yaml_attribute_without_tag",


### PR DESCRIPTION
## Summary

This PR fixes attribute lookup and YAML tag handling in two related places:

- `Value.Attribute` now falls back to declaration attributes when no matching field attribute exists.
- YAML encoding for embedded expressions now only overrides the node tag when `@yaml(...,tag=...)` is explicitly present.
- Embedded bare `ast.Expr` values (emitted by `Value.Syntax` in some list/struct cases) are now handled consistently with `EmbedDecl`.
- Added focused regression tests for declaration attributes on list elements and for preserving intrinsic tags on untagged embeds (for example `!!binary`).

## Why

- Some declaration attributes (including list element attrs) were not discoverable via `Value.Attribute`.
- Embed encoding could clear intrinsic tags when no YAML `tag` argument was present, which changed output semantics.

Addresses #4269 