### PR TITLE
encoding/protobuf: respect lexical scoping rules

### DIFF
--- a/encoding/protobuf/parse.go
+++ b/encoding/protobuf/parse.go
@@ -259,40 +259,52 @@ func (p *protoConverter) resolve(pos scanner.Position, name string, options []*p
 		return expr
 	}
 	if strings.HasPrefix(name, ".") {
-		return p.resolveTopScope(pos, name[1:], options)
+		// A leading dot indicates the path should be resolved in the top-level scope.
+		return p.resolveUsingScopes(pos, name[1:], p.scope[:1])
 	}
-	for _, scope := range slices.Backward(p.scope) {
-		if m, ok := scope[name]; ok {
-			return m.cue()
-		}
-	}
-	expr := p.resolveTopScope(pos, name, options)
+	// Non-absolute names need to be resolved using the nearest lexical scopes.
+	expr := p.resolveUsingScopes(pos, name, p.scope)
 	return expr
 }
 
-func (p *protoConverter) resolveTopScope(pos scanner.Position, name string, options []*proto.Option) ast.Expr {
+// resolveUsingScopes resolves a name using the nearest lexical scopes.
+// If the name is package-qualified, for this package, we trim the package prefix before searching.
+// If the name is dotted, we split the name and look for the first segment in the nearest lexical scope.
+// If the name is not found, we fail (panic with error).
+// scopes is a list of scopes to search, starting from the nearest scope;
+// to limit the search to a specific scope, pass that scope alone.
+func (p *protoConverter) resolveUsingScopes(pos scanner.Position, name string, scopes []map[string]mapping) ast.Expr {
 	for i := 0; i < len(name); i++ {
+		// Get the first segment of the name, advancing the index to the next dot.
 		k := strings.IndexByte(name[i:], '.')
 		i += k
 		if k == -1 {
 			i = len(name)
 		}
 		curName := name[:i]
+		// If the name is package-qualified, for this package, we can use the local name.
 		if local, ok := strings.CutPrefix(curName, p.protoPkg+"."); ok {
 			curName = local
 		}
-		if m, ok := p.scope[0][curName]; ok {
+		// Look for the name in the nearest scope.
+		for _, scope := range slices.Backward(scopes) {
+			m, ok := scope[curName]
+			if !ok {
+				continue
+			}
 			if m.pkg != nil {
 				p.imported[m.pkg.qualifiedImportPath()] = true
 			}
 			expr := m.cue()
 			for i < len(name) {
+				// The actual expression is pointing to a nested message, so we need to namespace it:
 				name = name[i+1:]
 				if i = strings.IndexByte(name, '.'); i == -1 {
 					i = len(name)
 				}
 				expr = ast.NewSel(expr, "#"+name[:i])
 			}
+
 			ast.SetPos(expr, p.toCUEPos(pos))
 			return expr
 		}

--- a/encoding/protobuf/protobuf_test.go
+++ b/encoding/protobuf/protobuf_test.go
@@ -67,7 +67,7 @@ func TestExtractDefinitions(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(out.String(), string(b)); diff != "" {
+			if diff := cmp.Diff(string(b), out.String()); diff != "" {
 				t.Error(diff)
 			}
 		})

--- a/encoding/protobuf/testdata/full_references.proto.out.cue
+++ b/encoding/protobuf/testdata/full_references.proto.out.cue
@@ -10,4 +10,54 @@ package full_references
 		value?: string @protobuf(1,string)
 	}
 	nestedMsg?: #FullReferenceNestedMsg.#FullReferenceDoubleNestedMsg @protobuf(1,istio.io.api.other.full_references.FullReferenceNestedMsg.FullReferenceDoubleNestedMsg,name=nested_msg)
+
+	#InnerContainer: {
+		#InnerEnum: {"INNER_ENUM_VALUE_1", #enumValue: 0} |
+			{"INNER_ENUM_VALUE_2", #enumValue: 1}
+
+		#InnerEnum_value: {
+			INNER_ENUM_VALUE_1: 0
+			INNER_ENUM_VALUE_2: 1
+		}
+	}
+
+	// This is a reference to a nested enum within the InnerContainer message,
+	// and should resolve correctly to the InnerEnum type via the relative dotted path.
+	relativeReference?: #InnerContainer.#InnerEnum @protobuf(2,InnerContainer.InnerEnum,name=relative_reference)
+
+	// AmbiguousMsg is a message that is ambiguous between a top-level message and a nested message.
+	#AmbiguousMsg: {
+
+		#Inner: {
+			// nested_field is a field that distinguishes this Inner from the in the top-level AmbiguousMsg message.
+			nestedField?: string @protobuf(1,string,name=nested_field)
+		}
+	}
+
+	// This is a fully-qualified reference to the top-level AmbiguousMsg message.
+	// This does not actually work correctly.
+	// TODO: Disambiguate this reference in generated CUE once aliasv2 is non-experimental
+	// and we can define something like `let <package> = self` without requiring experiment opt-in.
+	absoluteOuter?: #AmbiguousMsg @protobuf(3,.AmbiguousMsg,name=absolute_outer)
+
+	// This is a fully-qualified reference to the nested Inner message of the top-level AmbiguousMsg message.
+	// This does not actually work correctly.
+	// TODO: Disambiguate this reference in generated CUE once aliasv2 is non-experimental
+	// and we can define something like `let <package> = self` without requiring experiment opt-in.
+	absoluteInner?: #AmbiguousMsg.#Inner @protobuf(4,.AmbiguousMsg.Inner,name=absolute_inner)
+
+	// This is a relative reference to the nested AmbiguousMsg message.
+	relativeOuter?: #AmbiguousMsg @protobuf(5,AmbiguousMsg,name=relative_outer)
+
+	// This is a relative reference to the nested Inner message of the nested AmbiguousMsg message.
+	relativeInner?: #AmbiguousMsg.#Inner @protobuf(6,AmbiguousMsg.Inner,name=relative_inner)
+}
+
+// AmbiguousMsg is a message that is ambiguous between a top-level message and a nested message.
+#AmbiguousMsg: {
+
+	#Inner: {
+		// top_level_inner is a field that distinguishes this Inner from the one nested in FullReferenceMsg.
+		topLevelInner?: string @protobuf(1,string,name=top_level_inner)
+	}
 }

--- a/encoding/protobuf/testdata/istio.io/api/other/full_references.proto
+++ b/encoding/protobuf/testdata/istio.io/api/other/full_references.proto
@@ -12,4 +12,48 @@ message FullReferenceNestedMsg {
   }
 
   istio.io.api.other.full_references.FullReferenceNestedMsg.FullReferenceDoubleNestedMsg nested_msg = 1;
+
+  message InnerContainer {
+    enum InnerEnum {
+      INNER_ENUM_VALUE_1 = 0;
+      INNER_ENUM_VALUE_2 = 1;
+    }
+  }
+
+  // This is a reference to a nested enum within the InnerContainer message,
+  // and should resolve correctly to the InnerEnum type via the relative dotted path.
+  InnerContainer.InnerEnum relative_reference = 2;
+
+  // AmbiguousMsg is a message that is ambiguous between a top-level message and a nested message.
+  message AmbiguousMsg {
+
+    message Inner { 
+      // nested_field is a field that distinguishes this Inner from the in the top-level AmbiguousMsg message.
+      string nested_field = 1;
+    }
+  }
+
+  // This is a fully-qualified reference to the top-level AmbiguousMsg message.
+  // This does not actually work correctly.
+  // TODO: Disambiguate this reference in generated CUE once aliasv2 is non-experimental
+	// and we can define something like `let <package> = self` without requiring experiment opt-in.
+  .AmbiguousMsg absolute_outer = 3;
+  // This is a fully-qualified reference to the nested Inner message of the top-level AmbiguousMsg message.
+  // This does not actually work correctly.
+  // TODO: Disambiguate this reference in generated CUE once aliasv2 is non-experimental
+	// and we can define something like `let <package> = self` without requiring experiment opt-in.
+  .AmbiguousMsg.Inner absolute_inner = 4;
+  // This is a relative reference to the nested AmbiguousMsg message.
+  AmbiguousMsg relative_outer = 5;
+  // This is a relative reference to the nested Inner message of the nested AmbiguousMsg message.
+  AmbiguousMsg.Inner relative_inner = 6;
+}
+
+// AmbiguousMsg is a message that is ambiguous between a top-level message and a nested message.
+message AmbiguousMsg {
+
+  message Inner {
+    // top_level_inner is a field that distinguishes this Inner from the one nested in FullReferenceMsg.
+    string top_level_inner = 1;
+  }
 }


### PR DESCRIPTION
This change modifies the protobuf converter to
respect lexical scoping when resolving relative
references. Previously, relative references were
resolved using the top-level scope, which meant
that references which were not fully-qualified
would fail to resolve. This change modifies the
logic so that it searches for the first element
of the reference name by iterating up the scope
chain until it finds a match.

This extends the existing .proto file used for
testing references to include a variety of
reference types, including relative,
fully-qualified, and ambiguous references.
It does NOT fix the existing bug where
non-fully-qualified references to shadowed
names end up always resolving to the shadowed
name in the generated CUE, because changing that
would require making the generated code opt in
to the experimental aliasv2 feature, which may
not be desirabled for all users.

This also fixes a bug in the proto generation
tests where the diff for golden files was
reversed, leading to confusing test failure
messages.

This work used LLM-powered tab completion,
but no other LLM tools.

Fixes cue-lang/cue#4323