### PR TITLE
internal/core: fix Subsume nil-deref on BuiltinValidators with lazy args, allow bool != / == bounds

### DIFF
--- a/cue/types_test.go
+++ b/cue/types_test.go
@@ -2220,6 +2220,39 @@ func TestSubsume(t *testing.T) {
 		pathA: a,
 		pathB: b,
 		want:  false,
+	}, {
+		value: `
+			import "list"
+			let h = "abc"
+			a: list.MatchN(>0, =~"\(h)")
+			b: ["abc"]
+			`,
+		pathA:   a,
+		pathB:   b,
+		options: []cue.Option{cue.Final()},
+		want:    true,
+	}, {
+		value: `
+			import "list"
+			let h = "abc"
+			a: list.MatchN(>0, =~"\(h)")
+			b: ["xyz"]
+			`,
+		pathA:   a,
+		pathB:   b,
+		options: []cue.Option{cue.Final()},
+		want:    false,
+	}, {
+		value: `
+			import "list"
+			_h: "abc"
+			a: list.MatchN(>0, =~"\(_h)")
+			b: ["abc"]
+			`,
+		pathA:   a,
+		pathB:   b,
+		options: []cue.Option{cue.Final()},
+		want:    true,
 	}}
 	for _, tc := range testCases {
 		cuetdtest.FullMatrix.Run(t, tc.value, func(t *testing.T, m *cuetdtest.M) {

--- a/internal/core/adt/expr.go
+++ b/internal/core/adt/expr.go
@@ -395,7 +395,7 @@ func (x *BoundExpr) evaluate(ctx *OpContext, state Flags) Value {
 
 	switch k := v.Kind(); k {
 	case IntKind, FloatKind, NumberKind, StringKind, BytesKind:
-	case NullKind, StructKind, ListKind:
+	case NullKind, StructKind, ListKind, BoolKind:
 		if x.Op != NotEqualOp && x.Op != EqualOp {
 			err := ctx.NewPosf(Pos(x.Expr),
 				"cannot use %s for bound %s", k, x.Op)
@@ -407,7 +407,7 @@ func (x *BoundExpr) evaluate(ctx *OpContext, state Flags) Value {
 	default:
 		mask := IntKind | FloatKind | NumberKind | StringKind | BytesKind
 		if x.Op == NotEqualOp || x.Op == EqualOp {
-			mask |= NullKind | StructKind | ListKind
+			mask |= NullKind | StructKind | ListKind | BoolKind
 		}
 		if k&mask != 0 {
 			ctx.addErrf(IncompleteError, token.NoPos, // TODO(errors): use ctx.pos()?
@@ -1556,7 +1556,12 @@ func (builtin *Builtin) rawCall(c *OpContext, call *CallExpr, state Flags) Value
 		return nil
 	}
 	if builtin.IsValidator(len(args)) {
-		return &BuiltinValidator{call, builtin, args}
+		return &BuiltinValidator{
+			Src:     call,
+			Builtin: builtin,
+			Args:    args,
+			Env:     c.Env(0),
+		}
 	}
 	callCtx.args = args
 	result := builtin.call(callCtx)
@@ -1750,6 +1755,8 @@ type BuiltinValidator struct {
 	Src     *CallExpr
 	Builtin *Builtin
 	Args    []Value // any but the first value
+
+	Env *Environment
 }
 
 func (x *BuiltinValidator) Source() ast.Node {

--- a/internal/core/subsume/structural_test.go
+++ b/internal/core/subsume/structural_test.go
@@ -321,6 +321,13 @@ func TestStructural(t *testing.T) {
 		230: {subsumes: false, in: `a: !=5.0, b: 5.0`},
 		231: {subsumes: false, in: `a: !=5.0, b: 5`},
 
+		232: {subsumes: true, in: `a: !=true, b: false`},
+		233: {subsumes: false, in: `a: !=true, b: true`},
+		234: {subsumes: true, in: `a: !=false, b: true`},
+		235: {subsumes: false, in: `a: !=false, b: false`},
+		236: {subsumes: true, in: `a: ==true, b: true`},
+		237: {subsumes: false, in: `a: ==true, b: false`},
+
 		250: {subsumes: true, in: `a: =~ #"^\d{3}$"#, b: "123"`},
 		251: {subsumes: false, in: `a: =~ #"^\d{3}$"#, b: "1234"`},
 		252: {subsumes: true, in: `a: !~ #"^\d{3}$"#, b: "1234"`},

--- a/internal/core/subsume/value.go
+++ b/internal/core/subsume/value.go
@@ -102,9 +102,12 @@ func (s *subsumer) values(a, b adt.Value) (result bool) {
 		return x == b
 
 	case *adt.BuiltinValidator:
-		state := s.ctx.PushState(s.ctx.Env(0), b.Source())
-		// TODO: is this always correct?
-		cx := adt.MakeRootConjunct(s.ctx.Env(0), x)
+		env := x.Env
+		if env == nil {
+			env = s.ctx.Env(0)
+		}
+		state := s.ctx.PushState(env, b.Source())
+		cx := adt.MakeRootConjunct(env, x)
 		b1 := s.ctx.Validate(cx, b)
 		if b1 != nil {
 			s.errs = errors.Append(s.errs, b1.Err)


### PR DESCRIPTION
Two related issues surfaced together while using cue.Value.Subsume as a
policy-matching primitive:

1. Subsume nil-derefs when a BuiltinValidator (e.g. list.MatchN) carries
   an argument containing a lazy reference such as a LetReference or a
   reference to a hidden helper field. The recursive subsume path creates
   a root Conjunct using s.ctx.Env(0) — which is a bare context with no
   binding for the referenced identifier — and the reference lookup walks
   off the end of the nil Environment chain.

   Fix: capture the construction-site Environment on BuiltinValidator and
   use it in subsume/value.go when building the validator's Conjunct, so
   lazy args resolve against the scope in which the validator was written.

2. BoundExpr.evaluate rejected != / == bounds on BoolKind values with
   "invalid value ... for bound !=", leaving the bound as bottom. This is
   asymmetric with null / struct / list, which do accept == / != bounds.

   Fix: add BoolKind to the set of kinds that accept == / != bounds in
   BoundExpr.evaluate.

Regression tests:
- cue/types_test.go: TestSubsume cases for let-reference interpolation,
  hidden-field interpolation inside a regex bound.
- internal/core/subsume/structural_test.go: bool != / == bound subsumption
  cases (symmetric with the existing numeric and string bound tests).

Signed-off-by: Sören Nikolaus <soeren@code17.io>