### PR TITLE
encoding/protobuf: resolve unqualified references to package-less proto types

### DIFF
--- a/encoding/protobuf/parse.go
+++ b/encoding/protobuf/parse.go
@@ -388,8 +388,13 @@ func (p *protoConverter) doImport(v *proto.Import) error {
 		fail(v.Position, err)
 	}
 
-	pkgNamespace := strings.Split(imp.protoPkg, ".")
-	curNamespace := strings.Split(p.protoPkg, ".")
+	var pkgNamespace, curNamespace []string
+	if imp.protoPkg != "" {
+		pkgNamespace = strings.Split(imp.protoPkg, ".")
+	}
+	if p.protoPkg != "" {
+		curNamespace = strings.Split(p.protoPkg, ".")
+	}
 	for {
 		for k := range imp.symbols {
 			ref := k

--- a/encoding/protobuf/protobuf_test.go
+++ b/encoding/protobuf/protobuf_test.go
@@ -38,6 +38,7 @@ func TestExtractDefinitions(t *testing.T) {
 		"mixer/v1/config/client/client_config.proto",
 		"other/trailcomment.proto",
 		"other/full_references.proto",
+		"other/package_less_import.proto",
 	}
 	for _, file := range testCases {
 		t.Run(file, func(t *testing.T) {

--- a/encoding/protobuf/testdata/istio.io/api/other/global_scope.proto
+++ b/encoding/protobuf/testdata/istio.io/api/other/global_scope.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+// This file intentionally declares no `package`: its messages live in the
+// global proto namespace. It mirrors well-known-type style files that are
+// imported and referenced unqualified from other, named packages.
+option go_package = "istio.io/api/other/global_scope;global_scope";
+
+message GlobalMessage {
+  int64 value = 1;
+}

--- a/encoding/protobuf/testdata/istio.io/api/other/package_less_import.proto
+++ b/encoding/protobuf/testdata/istio.io/api/other/package_less_import.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package istio.io.api.other.package_less_import;
+
+import "other/global_scope.proto";
+
+// PackageLessImport references GlobalMessage unqualified. GlobalMessage is
+// declared in a package-less file, so it lives in the global proto scope and
+// is reachable without qualification, exactly as protoc resolves it.
+message PackageLessImport {
+  GlobalMessage global = 1;
+}

--- a/encoding/protobuf/testdata/package_less_import.proto.out.cue
+++ b/encoding/protobuf/testdata/package_less_import.proto.out.cue
@@ -1,0 +1,10 @@
+package package_less_import
+
+import "istio.io/api/other/global_scope"
+
+// PackageLessImport references GlobalMessage unqualified. GlobalMessage is
+// declared in a package-less file, so it lives in the global proto scope and
+// is reachable without qualification, exactly as protoc resolves it.
+#PackageLessImport: {
+	global?: global_scope.#GlobalMessage @protobuf(1,GlobalMessage)
+}


### PR DESCRIPTION
Fixes #4416.

`cue import proto` failed to resolve an unqualified reference to a type
declared in a `.proto` file with no `package` declaration when referenced from
another package, because `strings.Split("", ".")` returns `[""]` and the
symbol was registered under a leading-dot key (`.Foo`) that no reference
resolves to. `protoc` accepts the same input. See the linked issue for a
minimal reproduction.

Adds a `testdata` fixture (a package-less proto imported and referenced
unqualified from a named package); no existing fixture omitted a `package`
clause, which is why this was uncaught.
