### PR TITLE
update encoding/openapi error instead of panic on unsupported selectors

### DIFF
--- a/encoding/openapi/build.go
+++ b/encoding/openapi/build.go
@@ -181,12 +181,7 @@ func (c *buildContext) isInternal(sel cue.Selector) bool {
 }
 
 func (b *builder) failf(v cue.Value, format string, args ...interface{}) {
-	panic(&openapiError{
-		errors.NewMessagef(format, args...),
-		v.Err(),
-		cue.MakePath(b.ctx.path...),
-		v.Pos(),
-	})
+	b.ctx.failf(v, format, args...)
 }
 
 func (b *builder) unsupported(v cue.Value) {
@@ -721,7 +716,10 @@ func (b *builder) object(v cue.Value) {
 		if b.ctx.isInternal(sel) {
 			continue
 		}
-		label := selectorLabel(sel)
+		label, ok := selectorLabel(sel)
+		if !ok {
+			b.failf(i.Value(), "cannot create OpenAPI property name for %v", sel)
+		}
 		var core *builder
 		if b.core != nil {
 			core = b.core.properties[label]
@@ -1232,6 +1230,15 @@ func (b *builder) addRef(v cue.Value, inst cue.Value, ref cue.Path) {
 	}
 }
 
+func (b *buildContext) failf(v cue.Value, format string, args ...interface{}) {
+	panic(&openapiError{
+		errors.NewMessagef(format, args...),
+		v.Err(),
+		cue.MakePath(b.path...),
+		v.Pos(),
+	})
+}
+
 func (b *buildContext) makeRef(inst cue.Value, ref cue.Path) string {
 	if b.nameFunc != nil {
 		return b.nameFunc(inst, ref)
@@ -1242,7 +1249,11 @@ func (b *buildContext) makeRef(inst cue.Value, ref cue.Path) string {
 			buf.WriteByte('.')
 		}
 		// TODO what should this do when it's not a valid identifier?
-		buf.WriteString(selectorLabel(sel))
+		label, ok := selectorLabel(sel)
+		if !ok {
+			b.failf(inst, "cannot create OpenAPI reference for %v: unsupported path element %v", ref, sel)
+		}
+		buf.WriteString(label)
 	}
 	return buf.String()
 }
@@ -1281,18 +1292,18 @@ func (b *builder) big(v cue.Value) ast.Expr {
 	return v.Syntax(cue.Final()).(ast.Expr)
 }
 
-func selectorLabel(sel cue.Selector) string {
+// selectorLabel returns the OpenAPI reference name component for sel and
+// reports whether sel can be represented at all: only non-hidden fields,
+// definitions, and pattern constraints are supported.
+func selectorLabel(sel cue.Selector) (label string, ok bool) {
 	if sel.Type().ConstraintType() == cue.PatternConstraint {
-		return "*"
+		return "*", true
 	}
 	switch sel.LabelType() {
 	case cue.StringLabel:
-		return sel.Unquoted()
+		return sel.Unquoted(), true
 	case cue.DefinitionLabel:
-		return sel.String()[1:]
+		return sel.String()[1:], true
 	}
-	// We shouldn't get anything other than non-hidden
-	// fields and definitions because we've not asked the
-	// Fields iterator for those or created them explicitly.
-	panic(fmt.Sprintf("unreachable %v", sel.Type()))
+	return "", false
 }

--- a/encoding/openapi/openapi_test.go
+++ b/encoding/openapi/openapi_test.go
@@ -161,6 +161,21 @@ func TestIssue1234(t *testing.T) {
 	}
 }
 
+func TestIssue2530(t *testing.T) {
+	val := cuecontext.New().CompileString(`
+#List: [int]
+#A: #List[0]
+	`)
+	if err := val.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := openapi.Gen(val, &openapi.Config{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
 // This is for debugging purposes. Do not remove.
 func TestX(t *testing.T) {
 	t.Skip()


### PR DESCRIPTION
fix: update encoding/openapi to fail with an error instead of a panic when unsupported selectors are found.

- Updates selectorLabel() to return ok so it can return false instead of a panic.
- Moves failf() logic from builder to buildcontext so that failf() can be accessed from either.
- Updates unsupported() in the builder to check if selectorLabel() returns false and uses failf() to return a helpful error message.

Replaces 'panic: unreachable IndexLabel [recovered, repanicked]' with '#A: cannot create OpenAPI reference for #List[0]: unsupported path element 0' when running 'cue def schema.cue -o openapi+yaml:schema.yaml'.

This is not a cue v0.17 regression; cue v0.16.1 exhibits the same panic.

Improves #2530 so it at least doesn't panic.  The error message has proven useful in my testing.