### PR TITLE
internal/pretty: avoid blank line after comment-only files

### DIFF
--- a/cue/format/testdata/comments.txtar
+++ b/cue/format/testdata/comments.txtar
@@ -356,7 +356,6 @@ foo: [
 // Just one comment on its own.
 -- out/format/comment_alone.golden --
 // Just one comment on its own.
-
 -- comment_field.input --
 // Just one comment on a field.
 foo: string
@@ -369,7 +368,6 @@ foo: string
 -- out/format/comments_alone.golden --
 // Just a few comments
 // on their own.
-
 -- comments_field.input --
 // Just a few comments
 // on a field.
@@ -378,6 +376,12 @@ foo: string
 // Just a few comments
 // on a field.
 foo: string
+-- issue4404.input --
+// A file with a single comment block
+// and no empty line afterwards.
+-- out/format/issue4404.golden --
+// A file with a single comment block
+// and no empty line afterwards.
 -- issue1006.input --
 // issue #1006: comments should not be aligned across the opening
 // or closing token of a multi-line struct, list, or func call.

--- a/internal/pretty/ast.go
+++ b/internal/pretty/ast.go
@@ -331,7 +331,7 @@ func (c *converter) file(f *ast.File) doc {
 	// (the first visible token after the file-level leading comments)
 	// is honoured - otherwise a blank line between a file-level comment
 	// and the next decl's doc comment is silently dropped.
-	var firstDeclSep doc = lineBreakHard
+	var firstDeclSep doc
 	if len(f.Decls) > 0 {
 		firstDeclSep = relBreakOr(LeadingRelPos(f.Decls[0]), lineBreakHard)
 	}


### PR DESCRIPTION
## Summary

Fixes #4404.

Prevent formatv2 from adding an empty line after a file that contains only top-level comments. File-level leading comments now get a separator only when a declaration follows.

## Changes

- Avoid adding a declaration separator to comment-only files.
- Add a two-line regression fixture and update the existing comment-only golden outputs to require a single terminating newline.

## Testing

- `go test ./cue/format -run TestFiles -count=1`
- `go test ./cue/format ./internal/pretty`
- `go test ./...`
- `gofmt -d internal/pretty/ast.go`
- `git diff --check`

Note: I used Codex to help inspect the code path and prepare this change. I reviewed the final diff and ran the listed checks locally.