### PR TITLE
internal/mod/modpkgload: canonicalize resolved import lookups

### DIFF
--- a/cmd/cue/cmd/testdata/script/module-major-version-default-qualified-collision.txtar
+++ b/cmd/cue/cmd/testdata/script/module-major-version-default-qualified-collision.txtar
@@ -1,0 +1,72 @@
+# A qualified import in an external module must use that module's default
+# major version even when the main module has already loaded the same
+# unversioned import under a different default.
+
+exec cue export .
+cmp stdout want-eval.txt
+
+-- cue.mod/module.cue --
+module: "example.com/main@v0"
+language: version: "v0.9.0"
+
+deps: {
+	"example.com/mod@v0": {
+		default: true
+		v: "v0.0.0"
+	}
+	"example.com/mod@v1": {
+		v: "v1.0.0"
+	}
+	"example.com/other": {
+		default: true
+		v: "v0.0.0"
+	}
+}
+-- main.cue --
+package main
+
+import (
+	"example.com/mod"
+	"example.com/other"
+)
+"mod": mod.value
+"other": other.value
+
+-- _registry/example.com_mod_v0.0.0/cue.mod/module.cue --
+module: "example.com/mod@v0"
+language: version: "v0.9.0"
+-- _registry/example.com_mod_v0.0.0/mod.cue --
+package mod
+
+value: "v0"
+
+-- _registry/example.com_mod_v1.0.0/cue.mod/module.cue --
+module: "example.com/mod@v1"
+language: version: "v0.9.0"
+-- _registry/example.com_mod_v1.0.0/mod.cue --
+package mod
+
+value: "v1"
+
+-- _registry/example.com_other_v0.0.0/cue.mod/module.cue --
+module: "example.com/other@v0"
+language: version: "v0.9.0"
+
+deps: {
+	"example.com/mod@v1": {
+		default: true
+		v: "v1.0.0"
+	}
+}
+-- _registry/example.com_other_v0.0.0/other.cue --
+package other
+
+import "example.com/mod:mod"
+
+value: mod.value
+
+-- want-eval.txt --
+{
+    "mod": "v0",
+    "other": "v1"
+}

--- a/cmd/cue/cmd/testdata/script/module-major-version-default-qualified.txtar
+++ b/cmd/cue/cmd/testdata/script/module-major-version-default-qualified.txtar
@@ -1,0 +1,58 @@
+# A redundant package qualifier must not prevent an external module's
+# unversioned import from using that module's default major version.
+# The main module deliberately does not import example.com/mod itself, so a
+# missed contextual rewrite cannot fall back to an unversioned package entry.
+
+exec cue mod tidy --check
+exec cue export .
+cmp stdout want-eval.txt
+
+-- cue.mod/module.cue --
+module: "example.com/main@v0"
+language: version: "v0.9.0"
+
+deps: {
+	"example.com/mod@v1": {
+		v: "v1.0.0"
+	}
+	"example.com/other": {
+		default: true
+		v: "v0.0.0"
+	}
+}
+-- main.cue --
+package main
+
+import "example.com/other"
+
+value: other.value
+
+-- _registry/example.com_mod_v1.0.0/cue.mod/module.cue --
+module: "example.com/mod@v1"
+language: version: "v0.9.0"
+-- _registry/example.com_mod_v1.0.0/mod.cue --
+package mod
+
+value: "v1"
+
+-- _registry/example.com_other_v0.0.0/cue.mod/module.cue --
+module: "example.com/other@v0"
+language: version: "v0.9.0"
+
+deps: {
+	"example.com/mod@v1": {
+		default: true
+		v: "v1.0.0"
+	}
+}
+-- _registry/example.com_other_v0.0.0/other.cue --
+package other
+
+import "example.com/mod:mod"
+
+value: mod.value
+
+-- want-eval.txt --
+{
+    "value": "v1"
+}

--- a/internal/mod/modpkgload/pkgload.go
+++ b/internal/mod/modpkgload/pkgload.go
@@ -123,7 +123,7 @@ type Package struct {
 	imports         []*Package         // packages imported by this one
 	inStd           bool
 	fromExternal    bool
-	resolvedImports map[string]string // raw import path → canonical versioned path
+	resolvedImports map[string]string // canonical rewrite input → canonical rewrite result
 
 	// Populated by postprocessing in [Packages.buildStacks]:
 	stack *Package // package importing this one in minimal import stack for this pkg
@@ -173,15 +173,18 @@ func (pkg *Package) Mod() module.Version {
 	return pkg.mod
 }
 
-// CanonicalImportPath returns the canonical versioned import path for the
-// given raw import path.
-// This is used for external module packages where the importing module's
-// default major versions differ from the main module's.
-func (pkg *Package) CanonicalImportPath(rawPath string) string {
-	if p, ok := pkg.resolvedImports[rawPath]; ok {
+// CanonicalImportPath returns the canonical resolved import path recorded for
+// sourcePath. The build layer supplies the spelling from the source file, but
+// resolvedImports is keyed by canonical paths produced during package scanning
+// and rewriting, so sourcePath is canonicalized for the lookup only.
+//
+// If no contextual rewrite was recorded, sourcePath is returned unchanged.
+func (pkg *Package) CanonicalImportPath(sourcePath string) string {
+	lookupPath := ast.ParseImportPath(sourcePath).Canonical().String()
+	if p, ok := pkg.resolvedImports[lookupPath]; ok {
 		return p
 	}
-	return rawPath
+	return sourcePath
 }
 
 func (pkg *Package) ModRoot() module.SourceLoc {

--- a/internal/mod/modpkgload/pkgload_test.go
+++ b/internal/mod/modpkgload/pkgload_test.go
@@ -105,6 +105,85 @@ func TestLoadPackages(t *testing.T) {
 	}
 }
 
+func TestPackageCanonicalImportPath(t *testing.T) {
+	pkg := &Package{
+		resolvedImports: map[string]string{
+			"example.com/default":        "example.com/default@v1",
+			"example.com/default:custom": "example.com/default@v1:custom",
+		},
+	}
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "canonical",
+			path: "example.com/default",
+			want: "example.com/default@v1",
+		},
+		{
+			name: "redundant qualifier",
+			path: "example.com/default:default",
+			want: "example.com/default@v1",
+		},
+		{
+			name: "nonredundant qualifier",
+			path: "example.com/default:custom",
+			want: "example.com/default@v1:custom",
+		},
+		{
+			name: "unmapped spelling",
+			path: "example.com/unmapped:unmapped",
+			want: "example.com/unmapped:unmapped",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			qt.Assert(t, qt.Equals(pkg.CanonicalImportPath(test.path), test.want))
+		})
+	}
+}
+
+func TestReplacementCanonicalImportPath(t *testing.T) {
+	repls := &Replacements{
+		reverse: map[string]string{
+			"replacement.example/foo": "original.example/bar",
+		},
+	}
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "qualifier becomes redundant",
+			path: "replacement.example/foo:bar",
+			want: "original.example/bar",
+		},
+		{
+			name: "implied qualifier becomes explicit",
+			path: "replacement.example/foo",
+			want: "original.example/bar:foo",
+		},
+		{
+			name: "nonredundant qualifier remains explicit",
+			path: "replacement.example/foo:custom",
+			want: "original.example/bar:custom",
+		},
+		{
+			name: "unmatched spelling",
+			path: "unmatched.example/foo:foo",
+			want: "unmatched.example/foo:foo",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			qt.Assert(t, qt.Equals(repls.CanonicalImportPath(test.path), test.want))
+		})
+	}
+}
+
 func TestFindPackageLocations(t *testing.T) {
 	versionForModule := func(ctx context.Context, prefixPath string) (module.Version, error) {
 		t.Logf("versionForModule %q", prefixPath)

--- a/internal/mod/modpkgload/replace.go
+++ b/internal/mod/modpkgload/replace.go
@@ -258,7 +258,8 @@ func (r *Replacements) Lookup(modulePath string) (Replacement, bool) {
 // module's namespace. For example, if original module "a.com/foo" is replaced
 // by "b.com/bar", then "b.com/bar/subpkg" is rewritten to "a.com/foo/subpkg".
 //
-// If no rewriting is needed, importPath is returned unchanged.
+// A rewritten path is returned in canonical form. If no rewriting is needed,
+// importPath is returned unchanged.
 func (r *Replacements) CanonicalImportPath(importPath string) string {
 	if r == nil {
 		return importPath
@@ -274,7 +275,7 @@ func (r *Replacements) CanonicalImportPath(importPath string) string {
 			} else {
 				parts.Path = origBase
 			}
-			return parts.String()
+			return parts.Canonical().String()
 		}
 		i := strings.LastIndex(p, "/")
 		if i < 0 {


### PR DESCRIPTION
Commit b24b39cf made unversioned imports resolve against the importing external module's defaults to address cue-lang/cue#4371. It records per-package rewrites to explicit major-version paths so cue/build's path-keyed cache does not conflate different resolutions.

That handoff assumed the module scanner and builder saw the same spelling. AllImports canonicalizes redundant qualifiers, while the build callback receives the original AST spelling. An entry recorded under example.com/mod was therefore queried as example.com/mod:mod. Depending on whether the main module had already loaded the unversioned identity, this either reused the wrong major or failed with no dependency found even though cue mod tidy accepted the graph.

Canonicalize the source spelling for the resolvedImports lookup only, returning it unchanged when no rewrite exists. This keeps the map canonical rewrite input to canonical rewrite result, preserves the canonical package-identity behavior from 26db19be and cue-lang/cue#3162, and avoids globally changing observable build.Instance.ImportPath values.

Replacement plumbing added in 74d78c17 can change whether a qualifier is redundant after rewriting a module path. Canonicalize rewritten replacement paths too, preventing noncanonical intermediate keys from weakening the invariant.

Cover the boundary and replacement cases directly, and add command regressions for both the hard miss and silent wrong-major reuse. The hard-miss fixture also verifies cue mod tidy --check succeeds.