### PR TITLE
internal/core/adt: include conjunct positions in undefined-field errors

### DIFF
--- a/internal/core/adt/errors.go
+++ b/internal/core/adt/errors.go
@@ -301,7 +301,11 @@ func (v *Vertex) reportFieldError(c *OpContext, pos token.Pos, f Feature, intMsg
 	if f.IsInt() {
 		err = c.NewPosf(pos, intMsg, f.Index(), iterutil.Count(v.Elems()))
 	} else {
-		err = c.NewPosf(pos, stringMsg, label)
+		verr := c.NewPosf(pos, stringMsg, label)
+		for cj := range v.LeafConjuncts() {
+			verr.AddPosition(cj.x)
+		}
+		err = verr
 	}
 	b := &Bottom{
 		Code: code,


### PR DESCRIPTION
When a string-label selector fails to resolve — `{one: "1", two: "2"}[n]` with `n` outside the struct — the resulting bottom carries only the position of the *selector* expression. The struct whose fields were searched contributes no positions, so a consumer cannot point at the mapping table that lacks the entry.

This change attaches the vertex's leaf-conjunct positions to the error in `(*Vertex).reportFieldError`, the same pattern `NewRequiredNotPresentError` in the same file already uses for required-field errors. The positions
travel in the error's `InputPositions()`, where wrappers can resolve them to their own source model.

- Additive positions only: no message text change, no API change.
- Motivating case: something I use maps every error position back to   "which declaration contributed this" — with this change, e.g. "no `one` entry in table `_numbers` (declared at platform.cue:17)" becomes derivable; without it, only the failing selector is nameable.

Tests: positions are covered by the existing error-position support.

Signed-off-by: Davor Ocelic <docelic@crystallabs.io>
